### PR TITLE
feat: Git Worktree 기반 WorktreeManager 구현

### DIFF
--- a/crates/belt-core/src/error.rs
+++ b/crates/belt-core/src/error.rs
@@ -21,4 +21,7 @@ pub enum BeltError {
 
     #[error("database error: {0}")]
     Database(String),
+
+    #[error("worktree error: {0}")]
+    Worktree(String),
 }

--- a/crates/belt-infra/src/worktree.rs
+++ b/crates/belt-infra/src/worktree.rs
@@ -1,99 +1,341 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
+use std::process::Command;
 
-use anyhow::Result;
-use async_trait::async_trait;
+use belt_core::error::BeltError;
 
-/// Worktree 관리 trait.
-#[async_trait]
+/// Git worktree lifecycle manager.
+///
+/// Abstracts worktree creation, cleanup, and existence checks
+/// so that callers don't need to interact with git commands directly.
 pub trait WorktreeManager: Send + Sync {
-    async fn create_or_reuse(&self, workspace_name: &str, source_id: &str) -> Result<PathBuf>;
-    async fn cleanup(&self, worktree_path: &Path) -> Result<()>;
-    fn exists(&self, worktree_path: &Path) -> bool;
+    /// Creates a worktree or reuses an existing one for the given `work_id`.
+    fn create_or_reuse(&self, work_id: &str) -> Result<PathBuf, BeltError>;
+
+    /// Cleans up a worktree (`git worktree remove` + branch deletion).
+    fn cleanup(&self, work_id: &str) -> Result<(), BeltError>;
+
+    /// Returns `true` if a worktree for the given `work_id` exists.
+    fn exists(&self, work_id: &str) -> bool;
+
+    /// Returns the filesystem path for the worktree associated with `work_id`.
+    fn path(&self, work_id: &str) -> PathBuf;
 }
 
-/// 테스트용 MockWorktreeManager — 임시 디렉토리 기반.
+/// Sanitizes a `work_id` so it is safe for use as a directory name and git branch suffix.
+///
+/// Characters that are not alphanumeric, `-`, or `_` are replaced with `_`.
+fn sanitize_work_id(work_id: &str) -> String {
+    work_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Real git-worktree-based implementation of [`WorktreeManager`].
+pub struct GitWorktreeManager {
+    /// Base directory where worktrees are created (e.g. `~/.belt/worktrees/`).
+    base_dir: PathBuf,
+    /// Path to the git repository.
+    repo_path: PathBuf,
+}
+
+impl GitWorktreeManager {
+    /// Creates a new `GitWorktreeManager`.
+    pub fn new(base_dir: PathBuf, repo_path: PathBuf) -> Self {
+        Self {
+            base_dir,
+            repo_path,
+        }
+    }
+
+    /// Returns the branch name used for a given sanitized work id.
+    fn branch_name(sanitized: &str) -> String {
+        format!("belt/{sanitized}")
+    }
+}
+
+impl WorktreeManager for GitWorktreeManager {
+    fn create_or_reuse(&self, work_id: &str) -> Result<PathBuf, BeltError> {
+        let wt_path = self.path(work_id);
+
+        if wt_path.exists() {
+            tracing::debug!(work_id, ?wt_path, "worktree already exists, reusing");
+            return Ok(wt_path);
+        }
+
+        let sanitized = sanitize_work_id(work_id);
+        let branch = Self::branch_name(&sanitized);
+
+        let output = Command::new("git")
+            .arg("worktree")
+            .arg("add")
+            .arg(&wt_path)
+            .arg("-b")
+            .arg(&branch)
+            .current_dir(&self.repo_path)
+            .output()
+            .map_err(|e| BeltError::Worktree(format!("failed to run git worktree add: {e}")))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(BeltError::Worktree(format!(
+                "git worktree add failed: {stderr}"
+            )));
+        }
+
+        tracing::info!(work_id, ?wt_path, "worktree created");
+        Ok(wt_path)
+    }
+
+    fn cleanup(&self, work_id: &str) -> Result<(), BeltError> {
+        let wt_path = self.path(work_id);
+        let sanitized = sanitize_work_id(work_id);
+        let branch = Self::branch_name(&sanitized);
+
+        // git worktree remove --force <path>
+        let output = Command::new("git")
+            .args(["worktree", "remove", "--force"])
+            .arg(&wt_path)
+            .current_dir(&self.repo_path)
+            .output()
+            .map_err(|e| BeltError::Worktree(format!("failed to run git worktree remove: {e}")))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(BeltError::Worktree(format!(
+                "git worktree remove failed: {stderr}"
+            )));
+        }
+
+        // git branch -D belt/<sanitized>
+        let output = Command::new("git")
+            .args(["branch", "-D", &branch])
+            .current_dir(&self.repo_path)
+            .output()
+            .map_err(|e| BeltError::Worktree(format!("failed to run git branch -D: {e}")))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(BeltError::Worktree(format!(
+                "git branch -D failed: {stderr}"
+            )));
+        }
+
+        tracing::info!(work_id, ?wt_path, "worktree cleaned up");
+        Ok(())
+    }
+
+    fn exists(&self, work_id: &str) -> bool {
+        self.path(work_id).exists()
+    }
+
+    fn path(&self, work_id: &str) -> PathBuf {
+        let sanitized = sanitize_work_id(work_id);
+        self.base_dir.join(sanitized)
+    }
+}
+
+/// Mock implementation of [`WorktreeManager`] for testing.
+///
+/// Creates and removes plain directories instead of real git worktrees.
 pub struct MockWorktreeManager {
+    /// Base directory for mock worktrees.
     base_dir: PathBuf,
 }
 
 impl MockWorktreeManager {
-    pub fn new(base_dir: &Path) -> Self {
-        Self {
-            base_dir: base_dir.to_path_buf(),
-        }
+    /// Creates a new `MockWorktreeManager`.
+    pub fn new(base_dir: PathBuf) -> Self {
+        Self { base_dir }
     }
 }
 
-#[async_trait]
 impl WorktreeManager for MockWorktreeManager {
-    async fn create_or_reuse(&self, workspace_name: &str, source_id: &str) -> Result<PathBuf> {
-        let safe_name = source_id.replace([':', '/', '#'], "-");
-        let path = self.base_dir.join(format!("{workspace_name}-{safe_name}"));
-        if !path.exists() {
-            std::fs::create_dir_all(&path)?;
+    fn create_or_reuse(&self, work_id: &str) -> Result<PathBuf, BeltError> {
+        let wt_path = self.path(work_id);
+
+        if wt_path.exists() {
+            return Ok(wt_path);
         }
-        Ok(path)
+
+        std::fs::create_dir_all(&wt_path).map_err(|e| {
+            BeltError::Worktree(format!("failed to create mock worktree directory: {e}"))
+        })?;
+
+        Ok(wt_path)
     }
 
-    async fn cleanup(&self, worktree_path: &Path) -> Result<()> {
-        if worktree_path.exists() {
-            std::fs::remove_dir_all(worktree_path)?;
+    fn cleanup(&self, work_id: &str) -> Result<(), BeltError> {
+        let wt_path = self.path(work_id);
+
+        if wt_path.exists() {
+            std::fs::remove_dir_all(&wt_path).map_err(|e| {
+                BeltError::Worktree(format!("failed to remove mock worktree directory: {e}"))
+            })?;
         }
+
         Ok(())
     }
 
-    fn exists(&self, worktree_path: &Path) -> bool {
-        worktree_path.exists()
+    fn exists(&self, work_id: &str) -> bool {
+        self.path(work_id).exists()
+    }
+
+    fn path(&self, work_id: &str) -> PathBuf {
+        let sanitized = sanitize_work_id(work_id);
+        self.base_dir.join(sanitized)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
+    use std::fs;
 
-    #[tokio::test]
-    async fn create_and_cleanup() {
-        let tmp = TempDir::new().unwrap();
-        let mgr = MockWorktreeManager::new(tmp.path());
-        let path = mgr
-            .create_or_reuse("auth-project", "github:org/repo#42")
-            .await
-            .unwrap();
+    #[test]
+    fn sanitize_simple_id() {
+        assert_eq!(sanitize_work_id("hello-world"), "hello-world");
+    }
+
+    #[test]
+    fn sanitize_complex_id() {
+        assert_eq!(
+            sanitize_work_id("github:org/repo#42:implement"),
+            "github_org_repo_42_implement"
+        );
+    }
+
+    #[test]
+    fn sanitize_preserves_underscores_and_dashes() {
+        assert_eq!(sanitize_work_id("my_work-id"), "my_work-id");
+    }
+
+    #[test]
+    fn sanitize_all_special_chars() {
+        assert_eq!(sanitize_work_id("a!@#$%b"), "a_____b");
+    }
+
+    #[test]
+    fn sanitize_empty_string() {
+        assert_eq!(sanitize_work_id(""), "");
+    }
+
+    #[test]
+    fn mock_create_or_reuse_creates_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = MockWorktreeManager::new(tmp.path().to_path_buf());
+
+        let path = mgr.create_or_reuse("work-1").unwrap();
         assert!(path.exists());
-        mgr.cleanup(&path).await.unwrap();
-        assert!(!path.exists());
+        assert!(path.is_dir());
     }
 
-    #[tokio::test]
-    async fn reuse_existing() {
-        let tmp = TempDir::new().unwrap();
-        let mgr = MockWorktreeManager::new(tmp.path());
-        let path1 = mgr
-            .create_or_reuse("ws", "github:org/repo#42")
-            .await
-            .unwrap();
-        std::fs::write(path1.join("work.txt"), "previous work").unwrap();
-        let path2 = mgr
-            .create_or_reuse("ws", "github:org/repo#42")
-            .await
-            .unwrap();
-        assert_eq!(path1, path2);
-        assert!(path2.join("work.txt").exists());
+    #[test]
+    fn mock_create_or_reuse_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = MockWorktreeManager::new(tmp.path().to_path_buf());
+
+        let p1 = mgr.create_or_reuse("work-1").unwrap();
+        let p2 = mgr.create_or_reuse("work-1").unwrap();
+        assert_eq!(p1, p2);
     }
 
-    #[tokio::test]
-    async fn different_source_ids_get_different_paths() {
-        let tmp = TempDir::new().unwrap();
-        let mgr = MockWorktreeManager::new(tmp.path());
-        let p1 = mgr
-            .create_or_reuse("ws", "github:org/repo#1")
-            .await
-            .unwrap();
-        let p2 = mgr
-            .create_or_reuse("ws", "github:org/repo#2")
-            .await
-            .unwrap();
-        assert_ne!(p1, p2);
+    #[test]
+    fn mock_exists_returns_false_initially() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = MockWorktreeManager::new(tmp.path().to_path_buf());
+
+        assert!(!mgr.exists("work-1"));
+    }
+
+    #[test]
+    fn mock_exists_returns_true_after_create() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = MockWorktreeManager::new(tmp.path().to_path_buf());
+
+        mgr.create_or_reuse("work-1").unwrap();
+        assert!(mgr.exists("work-1"));
+    }
+
+    #[test]
+    fn mock_cleanup_removes_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = MockWorktreeManager::new(tmp.path().to_path_buf());
+
+        mgr.create_or_reuse("work-1").unwrap();
+        assert!(mgr.exists("work-1"));
+
+        mgr.cleanup("work-1").unwrap();
+        assert!(!mgr.exists("work-1"));
+    }
+
+    #[test]
+    fn mock_cleanup_nonexistent_is_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = MockWorktreeManager::new(tmp.path().to_path_buf());
+
+        // Should not error when cleaning up something that doesn't exist.
+        mgr.cleanup("nonexistent").unwrap();
+    }
+
+    #[test]
+    fn mock_path_uses_sanitized_work_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = MockWorktreeManager::new(tmp.path().to_path_buf());
+
+        let path = mgr.path("github:org/repo#42");
+        assert_eq!(path, tmp.path().join("github_org_repo_42"));
+    }
+
+    #[test]
+    fn git_worktree_manager_with_temp_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = tmp.path().join("repo");
+        let wt_base = tmp.path().join("worktrees");
+
+        fs::create_dir_all(&repo_path).unwrap();
+        fs::create_dir_all(&wt_base).unwrap();
+
+        // Initialize a bare-minimum git repo with an initial commit.
+        let run = |args: &[&str]| {
+            Command::new("git")
+                .args(args)
+                .current_dir(&repo_path)
+                .output()
+                .expect("git command failed")
+        };
+
+        run(&["init"]);
+        run(&["config", "user.email", "test@test.com"]);
+        run(&["config", "user.name", "Test"]);
+
+        // Create an initial commit so HEAD exists.
+        fs::write(repo_path.join("README"), "hello").unwrap();
+        run(&["add", "."]);
+        run(&["commit", "-m", "init"]);
+
+        let mgr = GitWorktreeManager::new(wt_base.clone(), repo_path.clone());
+
+        // create
+        let wt_path = mgr.create_or_reuse("task-1").unwrap();
+        assert!(wt_path.exists());
+        assert_eq!(wt_path, wt_base.join("task-1"));
+
+        // exists
+        assert!(mgr.exists("task-1"));
+
+        // reuse
+        let wt_path2 = mgr.create_or_reuse("task-1").unwrap();
+        assert_eq!(wt_path, wt_path2);
+
+        // cleanup
+        mgr.cleanup("task-1").unwrap();
+        assert!(!mgr.exists("task-1"));
     }
 }


### PR DESCRIPTION
## Summary
- `WorktreeManager` trait 정의 (create_or_reuse, cleanup, exists, path)
- `GitWorktreeManager`: `git worktree add/remove` 기반 실제 구현
- `MockWorktreeManager`: 테스트용 plain directory 기반 구현
- `sanitize_work_id()`: work_id → 파일시스템 안전 경로 변환
- `BeltError::Worktree` variant 추가

## Test plan
- [x] `cargo test -p belt-infra` — 13/13 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] Real git repo integration test (tempdir + git init)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)