### PR TITLE
feat: Claw 대화형 에이전트 모듈 구현

### DIFF
--- a/crates/belt-cli/Cargo.toml
+++ b/crates/belt-cli/Cargo.toml
@@ -19,3 +19,7 @@ anyhow = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+dirs = "6"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/belt-cli/src/claw.rs
+++ b/crates/belt-cli/src/claw.rs
@@ -1,0 +1,226 @@
+//! Claw interactive agent workspace management.
+//!
+//! Provides initialization, policy file management, and workspace structure
+//! for the Claw interactive management session.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Represents an initialized Claw workspace directory.
+pub struct ClawWorkspace {
+    /// Root path of the Claw workspace.
+    pub path: PathBuf,
+}
+
+impl ClawWorkspace {
+    /// Initialize a new Claw workspace under `belt_home`.
+    ///
+    /// Creates the directory structure:
+    /// ```text
+    /// {belt_home}/claw-workspace/
+    /// ├── CLAUDE.md
+    /// └── .claude/rules/
+    ///     ├── classify-policy.md
+    ///     ├── hitl-policy.md
+    ///     └── auto-approve-policy.md
+    /// ```
+    pub fn init(belt_home: &Path) -> anyhow::Result<ClawWorkspace> {
+        let workspace_path = belt_home.join("claw-workspace");
+        let rules_dir = workspace_path.join(".claude/rules");
+
+        fs::create_dir_all(&rules_dir)?;
+
+        fs::write(workspace_path.join("CLAUDE.md"), default_claude_md())?;
+        fs::write(
+            rules_dir.join("classify-policy.md"),
+            default_classify_policy(),
+        )?;
+        fs::write(rules_dir.join("hitl-policy.md"), default_hitl_policy())?;
+        fs::write(
+            rules_dir.join("auto-approve-policy.md"),
+            default_auto_approve_policy(),
+        )?;
+
+        Ok(ClawWorkspace {
+            path: workspace_path,
+        })
+    }
+
+    /// List policy rule files in the workspace.
+    pub fn list_rules(&self) -> anyhow::Result<Vec<PathBuf>> {
+        let rules_dir = self.path.join(".claude/rules");
+        if !rules_dir.exists() {
+            anyhow::bail!("rules directory not found: {}", rules_dir.display());
+        }
+
+        let mut files = Vec::new();
+        for entry in fs::read_dir(&rules_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_file() {
+                files.push(path);
+            }
+        }
+        files.sort();
+        Ok(files)
+    }
+}
+
+/// Returns the default CLAUDE.md content with belt CLI usage guide.
+pub fn default_claude_md() -> &'static str {
+    r#"# Belt Claw Workspace
+
+## Available Belt Commands
+
+### System Status
+- `belt status` — Show overall system status
+- `belt status --format json` — Machine-readable status output
+
+### Queue Management
+- `belt queue list` — List all queue items
+- `belt queue list --phase <phase>` — Filter items by phase
+- `belt queue list --workspace <name>` — Filter items by workspace
+- `belt queue show <work_id>` — Show details for a specific item
+- `belt queue done <work_id>` — Mark an item as completed
+- `belt queue hitl <work_id> --reason "<reason>"` — Escalate to human-in-the-loop
+- `belt queue skip <work_id>` — Skip an item
+
+### Workspace Management
+- `belt workspace list` — List registered workspaces
+- `belt workspace show <name>` — Show workspace details
+- `belt workspace add --config <path>` — Register a new workspace
+
+### Context
+- `belt context <work_id>` — Retrieve item context
+- `belt context <work_id> --json` — Retrieve context as JSON
+
+## Workflow
+1. Check system status with `belt status`
+2. Review queue items with `belt queue list`
+3. For each item, retrieve context and apply classification rules
+4. Items that pass auto-approve policy proceed automatically
+5. Items matching HITL policy are escalated for human review
+"#
+}
+
+/// Returns the default classify-policy template.
+pub fn default_classify_policy() -> &'static str {
+    r#"# Classification Policy
+
+## Purpose
+Classify incoming queue items into categories for routing.
+
+## Default Rules
+- Items with unknown data sources → HITL
+- Items matching a registered workspace pattern → auto-route
+- Items with missing required fields → reject
+
+## Categories
+- **auto**: Can be processed without human intervention
+- **hitl**: Requires human review before proceeding
+- **reject**: Invalid or incomplete items
+"#
+}
+
+/// Returns the default HITL policy template.
+pub fn default_hitl_policy() -> &'static str {
+    r#"# Human-in-the-Loop (HITL) Policy
+
+## Purpose
+Define when items require human review.
+
+## Default Triggers
+- Classification confidence below threshold
+- Destructive operations (delete, overwrite)
+- Items touching sensitive paths or data
+- First-time patterns not seen before
+
+## Escalation
+- When in doubt, escalate to HITL (safe default)
+- Provide context and reasoning with escalation
+- Include suggested action for reviewer
+"#
+}
+
+/// Returns the default auto-approve policy template.
+pub fn default_auto_approve_policy() -> &'static str {
+    r#"# Auto-Approve Policy
+
+## Purpose
+Define conditions under which items can proceed without human review.
+
+## Default Conditions
+- Item matches a known, previously-approved pattern
+- All required fields are present and valid
+- No destructive operations involved
+- Data source is registered and trusted
+
+## Safeguards
+- Auto-approved items are still logged for audit
+- Repeated failures from auto-approved patterns trigger re-evaluation
+- Rate limits apply to prevent runaway automation
+"#
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn init_creates_workspace_structure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = ClawWorkspace::init(tmp.path()).unwrap();
+
+        assert!(ws.path.exists());
+        assert!(ws.path.join("CLAUDE.md").is_file());
+        assert!(ws.path.join(".claude/rules/classify-policy.md").is_file());
+        assert!(ws.path.join(".claude/rules/hitl-policy.md").is_file());
+        assert!(
+            ws.path
+                .join(".claude/rules/auto-approve-policy.md")
+                .is_file()
+        );
+    }
+
+    #[test]
+    fn init_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws1 = ClawWorkspace::init(tmp.path()).unwrap();
+        let ws2 = ClawWorkspace::init(tmp.path()).unwrap();
+        assert_eq!(ws1.path, ws2.path);
+    }
+
+    #[test]
+    fn default_templates_are_not_empty() {
+        assert!(!default_claude_md().is_empty());
+        assert!(!default_classify_policy().is_empty());
+        assert!(!default_hitl_policy().is_empty());
+        assert!(!default_auto_approve_policy().is_empty());
+    }
+
+    #[test]
+    fn list_rules_returns_policy_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = ClawWorkspace::init(tmp.path()).unwrap();
+        let rules = ws.list_rules().unwrap();
+
+        let filenames: Vec<&str> = rules
+            .iter()
+            .filter_map(|p| p.file_name()?.to_str())
+            .collect();
+
+        assert!(filenames.contains(&"classify-policy.md"));
+        assert!(filenames.contains(&"hitl-policy.md"));
+        assert!(filenames.contains(&"auto-approve-policy.md"));
+        assert_eq!(filenames.len(), 3);
+    }
+
+    #[test]
+    fn list_rules_fails_without_init() {
+        let ws = ClawWorkspace {
+            path: Path::new("/nonexistent/path").to_path_buf(),
+        };
+        assert!(ws.list_rules().is_err());
+    }
+}

--- a/crates/belt-cli/src/main.rs
+++ b/crates/belt-cli/src/main.rs
@@ -1,7 +1,13 @@
 use clap::{Parser, Subcommand};
 
+mod claw;
+
 #[derive(Parser)]
-#[command(name = "belt", version, about = "Conveyor belt for autonomous development")]
+#[command(
+    name = "belt",
+    version,
+    about = "Conveyor belt for autonomous development"
+)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -37,6 +43,30 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Run an LLM agent session.
+    Agent {
+        /// Target workspace name.
+        #[arg(long)]
+        workspace: Option<String>,
+        /// Non-interactive prompt (for cron/evaluate calls).
+        #[arg(short, long)]
+        prompt: Option<String>,
+    },
+    /// Claw interactive management session.
+    Claw {
+        #[command(subcommand)]
+        command: ClawCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum ClawCommands {
+    /// Initialize Claw workspace.
+    Init,
+    /// Show/edit classification rules.
+    Rules,
+    /// Open interactive session.
+    Session,
 }
 
 #[derive(Subcommand)]
@@ -83,8 +113,7 @@ enum QueueCommands {
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
-            tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive("belt=info".parse()?),
+            tracing_subscriber::EnvFilter::from_default_env().add_directive("belt=info".parse()?),
         )
         .init();
 
@@ -135,6 +164,39 @@ async fn main() -> anyhow::Result<()> {
             tracing::info!(work_id, "fetching context...");
             // TODO: context retrieval
         }
+        Commands::Agent { workspace, prompt } => {
+            if let Some(name) = &workspace {
+                tracing::info!(name, "running agent for workspace...");
+            }
+            if let Some(p) = &prompt {
+                tracing::info!(p, "executing prompt...");
+            }
+            // TODO: AgentRuntime implementation
+        }
+        Commands::Claw { command } => match command {
+            ClawCommands::Init => {
+                let belt_home = dirs::home_dir()
+                    .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?
+                    .join(".belt");
+                let ws = claw::ClawWorkspace::init(&belt_home)?;
+                tracing::info!(path = %ws.path.display(), "claw workspace initialized");
+            }
+            ClawCommands::Rules => {
+                let belt_home = dirs::home_dir()
+                    .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?
+                    .join(".belt");
+                let ws = claw::ClawWorkspace {
+                    path: belt_home.join("claw-workspace"),
+                };
+                let rules = ws.list_rules()?;
+                for rule in &rules {
+                    println!("{}", rule.display());
+                }
+            }
+            ClawCommands::Session => {
+                tracing::info!("interactive session not yet implemented");
+            }
+        },
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- `belt-cli/src/claw.rs`: ClawWorkspace 구조체 + 기본 정책 템플릿
- `belt agent --workspace <name> -p <prompt>`: LLM 에이전트 실행 커맨드 (stub)
- `belt claw init/rules/session`: Claw workspace 관리 서브커맨드

## Claw Workspace 구조
```
~/.belt/claw-workspace/
├── CLAUDE.md
└── .claude/rules/
    ├── classify-policy.md
    ├── hitl-policy.md
    └── auto-approve-policy.md
```

## Test plan
- [x] `cargo test -p belt-cli` — 5/5 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] init 멱등성 테스트
- [x] 기본 템플릿 비어있지 않음 검증

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)