### PR TITLE
fix: HistoryEntry에 source_id, work_id 필드 추가

### DIFF
--- a/crates/belt-core/src/context.rs
+++ b/crates/belt-core/src/context.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 /// 모든 상태 변화를 기록하며, failure_count는 history에서 계산한다.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct HistoryEntry {
+    pub source_id: String,
+    pub work_id: String,
     pub state: String,
     pub status: HistoryStatus,
     pub attempt: u32,
@@ -137,6 +139,8 @@ mod tests {
 
     fn make_history_entry(state: &str, status: HistoryStatus, attempt: u32) -> HistoryEntry {
         HistoryEntry {
+            source_id: "github:org/repo#42".to_string(),
+            work_id: format!("github:org/repo#42:{state}"),
             state: state.to_string(),
             status,
             attempt,


### PR DESCRIPTION
## Summary
- `HistoryEntry` 구조체에 `source_id`, `work_id` 필드 추가
- 히스토리를 아이템별로 스코핑 가능 (count_failures 정확도 향상)

## Related
- #13 (count_failures source_id 필터링)

## Test plan
- [x] `cargo test -p belt-core` 통과
- [x] `cargo clippy -- -D warnings` 통과

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)