### PR TITLE
fix: concurrency 위치 수정 + on_enter 실패 시 escalation 적용

### DIFF
--- a/crates/belt-core/src/workspace.rs
+++ b/crates/belt-core/src/workspace.rs
@@ -8,6 +8,8 @@ use crate::escalation::EscalationPolicy;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkspaceConfig {
     pub name: String,
+    #[serde(default = "default_concurrency")]
+    pub concurrency: u32,
     #[serde(default)]
     pub sources: HashMap<String, SourceConfig>,
     #[serde(default)]
@@ -20,8 +22,6 @@ pub struct SourceConfig {
     pub url: String,
     #[serde(default = "default_scan_interval")]
     pub scan_interval_secs: u64,
-    #[serde(default = "default_concurrency")]
-    pub concurrency: u32,
     #[serde(default)]
     pub states: HashMap<String, StateConfig>,
     #[serde(default)]
@@ -120,7 +120,7 @@ impl WorkspaceRef {
             id: id.to_string(),
             name: config.name.clone(),
             url: source.url.clone(),
-            concurrency: source.concurrency,
+            concurrency: config.concurrency,
         })
     }
 }
@@ -131,11 +131,11 @@ mod tests {
 
     const WORKSPACE_YAML: &str = r#"
 name: auth-project
+concurrency: 2
 sources:
   github:
     url: https://github.com/org/repo
     scan_interval_secs: 300
-    concurrency: 2
     states:
       analyze:
         trigger:
@@ -171,9 +171,9 @@ runtime:
     fn parse_full_workspace_yaml() {
         let config: WorkspaceConfig = serde_yaml::from_str(WORKSPACE_YAML).unwrap();
         assert_eq!(config.name, "auth-project");
+        assert_eq!(config.concurrency, 2);
         let github = config.sources.get("github").unwrap();
         assert_eq!(github.url, "https://github.com/org/repo");
-        assert_eq!(github.concurrency, 2);
     }
 
     #[test]
@@ -193,7 +193,11 @@ runtime:
         let github = config.sources.get("github").unwrap();
         let implement = github.states.get("implement").unwrap();
         match &implement.handlers[0] {
-            HandlerConfig::Prompt { prompt, runtime, model } => {
+            HandlerConfig::Prompt {
+                prompt,
+                runtime,
+                model,
+            } => {
                 assert!(prompt.contains("구현"));
                 assert_eq!(runtime.as_deref(), Some("claude"));
                 assert_eq!(model.as_deref(), Some("sonnet"));
@@ -206,9 +210,9 @@ runtime:
     fn defaults() {
         let yaml = "name: minimal\nsources:\n  github:\n    url: https://github.com/org/repo\n";
         let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.concurrency, 1);
         let github = config.sources.get("github").unwrap();
         assert_eq!(github.scan_interval_secs, 300);
-        assert_eq!(github.concurrency, 1);
         assert_eq!(config.runtime.default, "claude");
     }
 

--- a/crates/belt-daemon/src/daemon.rs
+++ b/crates/belt-daemon/src/daemon.rs
@@ -87,13 +87,7 @@ impl Daemon {
         }
 
         let ws_id = &self.config.name;
-        let ws_concurrency = self
-            .config
-            .sources
-            .values()
-            .next()
-            .map(|s| s.concurrency)
-            .unwrap_or(1);
+        let ws_concurrency = self.config.concurrency;
 
         for item in self.queue.iter_mut() {
             if item.phase == QueuePhase::Ready
@@ -161,7 +155,25 @@ impl Daemon {
         // on_enter
         let on_enter: Vec<Action> = state_config.on_enter.iter().map(Action::from).collect();
         if let Err(e) = self.executor.execute_all(&on_enter, &env).await {
-            tracing::warn!("on_enter failed for {}: {e}", item.work_id);
+            // 1. Record failure
+            self.record_history(item, "failed", Some(&e.to_string()));
+            // 2. Count failures and resolve escalation
+            let failure_count = self.count_failures(&item.source_id, &item.state);
+            let escalation = self.resolve_escalation(&item.state, failure_count);
+            // 3. Run on_fail if needed
+            if escalation.should_run_on_fail() {
+                let on_fail: Vec<Action> = state_config.on_fail.iter().map(Action::from).collect();
+                let _ = self.executor.execute_all(&on_fail, &env).await;
+            }
+            // 4. Apply escalation (retry/hitl/skip)
+            self.handle_escalation(item, escalation);
+            self.tracker.release(&self.config.name.clone());
+
+            return ItemOutcome::Failed {
+                item: item.clone(),
+                error: format!("on_enter failed: {e}"),
+                escalation,
+            };
         }
 
         // handler chain
@@ -176,7 +188,8 @@ impl Daemon {
                 self.record_history(item, "failed", Some(&r.stderr));
 
                 if escalation.should_run_on_fail() {
-                    let on_fail: Vec<Action> = state_config.on_fail.iter().map(Action::from).collect();
+                    let on_fail: Vec<Action> =
+                        state_config.on_fail.iter().map(Action::from).collect();
                     let _ = self.executor.execute_all(&on_fail, &env).await;
                 }
 
@@ -224,12 +237,18 @@ impl Daemon {
         if state_config.on_done.is_empty() {
             item.phase = QueuePhase::Done;
             self.record_history(item, "done", None);
-            let worktree = self.worktree_mgr.create_or_reuse(&self.config.name, &item.source_id).await?;
+            let worktree = self
+                .worktree_mgr
+                .create_or_reuse(&self.config.name, &item.source_id)
+                .await?;
             let _ = self.worktree_mgr.cleanup(&worktree).await;
             return Ok(true);
         }
 
-        let worktree = self.worktree_mgr.create_or_reuse(&self.config.name, &item.source_id).await?;
+        let worktree = self
+            .worktree_mgr
+            .create_or_reuse(&self.config.name, &item.source_id)
+            .await?;
         let env = ActionEnv::new(&item.work_id, &worktree);
         let on_done: Vec<Action> = state_config.on_done.iter().map(Action::from).collect();
         let result = self.executor.execute_all(&on_done, &env).await?;
@@ -265,8 +284,17 @@ impl Daemon {
         for outcome in &outcomes {
             match outcome {
                 ItemOutcome::Completed(item) => tracing::info!("completed: {}", item.work_id),
-                ItemOutcome::Failed { item, error, escalation } => {
-                    tracing::warn!("failed: {} (escalation={:?}, error={})", item.work_id, escalation, error);
+                ItemOutcome::Failed {
+                    item,
+                    error,
+                    escalation,
+                } => {
+                    tracing::warn!(
+                        "failed: {} (escalation={:?}, error={})",
+                        item.work_id,
+                        escalation,
+                        error
+                    );
                 }
                 ItemOutcome::Skipped(item) => tracing::info!("skipped: {}", item.work_id),
             }
@@ -363,10 +391,17 @@ impl Daemon {
     }
 
     fn record_history(&mut self, item: &QueueItem, status: &str, error: Option<&str>) {
-        let attempt = self.history.iter().filter(|h| h.state == item.state).count() as u32 + 1;
+        let attempt = self
+            .history
+            .iter()
+            .filter(|h| h.state == item.state)
+            .count() as u32
+            + 1;
         self.history.push(HistoryEntry {
             state: item.state.clone(),
-            status: status.parse().unwrap_or(belt_core::context::HistoryStatus::Failed),
+            status: status
+                .parse()
+                .unwrap_or(belt_core::context::HistoryStatus::Failed),
             attempt,
             summary: None,
             error: error.map(|s| s.to_string()),
@@ -405,10 +440,10 @@ mod tests {
     fn test_workspace_config() -> WorkspaceConfig {
         let yaml = r#"
 name: test-ws
+concurrency: 2
 sources:
   github:
     url: https://github.com/org/repo
-    concurrency: 2
     states:
       analyze:
         trigger:


### PR DESCRIPTION
## Summary
- **#22**: `concurrency` 필드를 `SourceConfig` → `WorkspaceConfig` 루트로 이동
  - daemon의 workaround 제거, `self.config.concurrency` 직접 사용
- **#23**: on_enter 실패 시 handler 스킵 + 전체 escalation 정책 적용
  - history 기록, failure_count 계산, on_fail 실행, escalation 적용

## Test plan
- [x] `cargo test -p belt-core` — 42/42 통과
- [x] workspace YAML 파싱 테스트 업데이트
- [ ] multi-source workspace에서 concurrency 동작 확인

Closes #22, Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)