### PR TITLE
fix: Claw workspace init 디렉토리 추가 + 안전한 파일 보존

### DIFF
--- a/crates/belt-cli/src/claw.rs
+++ b/crates/belt-cli/src/claw.rs
@@ -12,6 +12,18 @@ pub struct ClawWorkspace {
     pub path: PathBuf,
 }
 
+/// Write `contents` to `path` only if the file does not already exist.
+///
+/// Returns `true` if the file was written, `false` if it was skipped.
+fn write_if_absent(path: &Path, contents: &str) -> std::io::Result<bool> {
+    if path.exists() {
+        Ok(false)
+    } else {
+        fs::write(path, contents)?;
+        Ok(true)
+    }
+}
+
 impl ClawWorkspace {
     /// Initialize a new Claw workspace under `belt_home`.
     ///
@@ -19,31 +31,105 @@ impl ClawWorkspace {
     /// ```text
     /// {belt_home}/claw-workspace/
     /// ├── CLAUDE.md
+    /// ├── commands/
+    /// ├── skills/
+    /// │   ├── gap-detect/
+    /// │   └── prioritize/
     /// └── .claude/rules/
     ///     ├── classify-policy.md
     ///     ├── hitl-policy.md
     ///     └── auto-approve-policy.md
     /// ```
+    ///
+    /// Existing files are preserved by default. Pass `force = true` to
+    /// overwrite them.
     pub fn init(belt_home: &Path) -> anyhow::Result<ClawWorkspace> {
+        Self::init_with_options(belt_home, false)
+    }
+
+    /// Initialize with explicit force-overwrite flag.
+    pub fn init_with_options(belt_home: &Path, force: bool) -> anyhow::Result<ClawWorkspace> {
         let workspace_path = belt_home.join("claw-workspace");
         let rules_dir = workspace_path.join(".claude/rules");
+        let commands_dir = workspace_path.join("commands");
+        let skills_dir = workspace_path.join("skills");
+        let gap_detect_dir = skills_dir.join("gap-detect");
+        let prioritize_dir = skills_dir.join("prioritize");
 
+        // Create all directories (idempotent).
         fs::create_dir_all(&rules_dir)?;
+        fs::create_dir_all(&commands_dir)?;
+        fs::create_dir_all(&gap_detect_dir)?;
+        fs::create_dir_all(&prioritize_dir)?;
 
-        fs::write(workspace_path.join("CLAUDE.md"), default_claude_md())?;
-        fs::write(
-            rules_dir.join("classify-policy.md"),
+        let write_file = |path: &Path, contents: &str| -> anyhow::Result<()> {
+            if force {
+                fs::write(path, contents)?;
+            } else {
+                let written = write_if_absent(path, contents)?;
+                if !written {
+                    tracing::info!(path = %path.display(), "file already exists, skipping");
+                }
+            }
+            Ok(())
+        };
+
+        write_file(&workspace_path.join("CLAUDE.md"), default_claude_md())?;
+        write_file(
+            &rules_dir.join("classify-policy.md"),
             default_classify_policy(),
         )?;
-        fs::write(rules_dir.join("hitl-policy.md"), default_hitl_policy())?;
-        fs::write(
-            rules_dir.join("auto-approve-policy.md"),
+        write_file(&rules_dir.join("hitl-policy.md"), default_hitl_policy())?;
+        write_file(
+            &rules_dir.join("auto-approve-policy.md"),
             default_auto_approve_policy(),
         )?;
 
         Ok(ClawWorkspace {
             path: workspace_path,
         })
+    }
+
+    /// Edit a rule file by name.
+    ///
+    /// Opens the rule file in `$EDITOR` (falls back to `vi`). If `rule` is
+    /// `None`, lists available rule files instead.
+    pub fn edit_rule(&self, rule: Option<&str>) -> anyhow::Result<()> {
+        let rules_dir = self.path.join(".claude/rules");
+        if !rules_dir.exists() {
+            anyhow::bail!("rules directory not found: {}", rules_dir.display());
+        }
+
+        let rule_name = match rule {
+            Some(name) => name,
+            None => {
+                // List available rules when no specific rule is given.
+                let rules = self.list_rules()?;
+                println!("Available rules:");
+                for r in &rules {
+                    if let Some(stem) = r.file_stem().and_then(|s| s.to_str()) {
+                        println!("  {stem}");
+                    }
+                }
+                return Ok(());
+            }
+        };
+
+        let file_path = rules_dir.join(format!("{rule_name}.md"));
+        if !file_path.exists() {
+            anyhow::bail!("rule file not found: {}", file_path.display());
+        }
+
+        let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
+        let status = std::process::Command::new(&editor)
+            .arg(&file_path)
+            .status()?;
+
+        if !status.success() {
+            anyhow::bail!("editor exited with status: {status}");
+        }
+
+        Ok(())
     }
 
     /// List policy rule files in the workspace.
@@ -184,6 +270,47 @@ mod tests {
     }
 
     #[test]
+    fn init_creates_commands_and_skills_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = ClawWorkspace::init(tmp.path()).unwrap();
+
+        assert!(ws.path.join("commands").is_dir());
+        assert!(ws.path.join("skills").is_dir());
+        assert!(ws.path.join("skills/gap-detect").is_dir());
+        assert!(ws.path.join("skills/prioritize").is_dir());
+    }
+
+    #[test]
+    fn init_preserves_existing_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = ClawWorkspace::init(tmp.path()).unwrap();
+
+        // Modify CLAUDE.md after initial init.
+        let custom_content = "# Custom content";
+        fs::write(ws.path.join("CLAUDE.md"), custom_content).unwrap();
+
+        // Re-init without force — should preserve the custom file.
+        let ws2 = ClawWorkspace::init(tmp.path()).unwrap();
+        let content = fs::read_to_string(ws2.path.join("CLAUDE.md")).unwrap();
+        assert_eq!(content, custom_content);
+    }
+
+    #[test]
+    fn init_force_overwrites_existing_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = ClawWorkspace::init(tmp.path()).unwrap();
+
+        // Modify CLAUDE.md after initial init.
+        let custom_content = "# Custom content";
+        fs::write(ws.path.join("CLAUDE.md"), custom_content).unwrap();
+
+        // Re-init with force — should overwrite.
+        let ws2 = ClawWorkspace::init_with_options(tmp.path(), true).unwrap();
+        let content = fs::read_to_string(ws2.path.join("CLAUDE.md")).unwrap();
+        assert_eq!(content, default_claude_md());
+    }
+
+    #[test]
     fn init_is_idempotent() {
         let tmp = tempfile::tempdir().unwrap();
         let ws1 = ClawWorkspace::init(tmp.path()).unwrap();
@@ -222,5 +349,20 @@ mod tests {
             path: Path::new("/nonexistent/path").to_path_buf(),
         };
         assert!(ws.list_rules().is_err());
+    }
+
+    #[test]
+    fn edit_rule_none_lists_rules() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = ClawWorkspace::init(tmp.path()).unwrap();
+        // Calling edit_rule(None) should not error — it lists available rules.
+        ws.edit_rule(None).unwrap();
+    }
+
+    #[test]
+    fn edit_rule_missing_file_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = ClawWorkspace::init(tmp.path()).unwrap();
+        assert!(ws.edit_rule(Some("nonexistent")).is_err());
     }
 }

--- a/crates/belt-cli/src/main.rs
+++ b/crates/belt-cli/src/main.rs
@@ -62,9 +62,18 @@ enum Commands {
 #[derive(Subcommand)]
 enum ClawCommands {
     /// Initialize Claw workspace.
-    Init,
+    Init {
+        /// Overwrite existing files.
+        #[arg(long)]
+        force: bool,
+    },
     /// Show/edit classification rules.
     Rules,
+    /// Edit classification/HITL rules.
+    Edit {
+        /// Rule file to edit (classify-policy, hitl-policy, auto-approve-policy).
+        rule: Option<String>,
+    },
     /// Open interactive session.
     Session,
 }
@@ -174,11 +183,15 @@ async fn main() -> anyhow::Result<()> {
             // TODO: AgentRuntime implementation
         }
         Commands::Claw { command } => match command {
-            ClawCommands::Init => {
+            ClawCommands::Init { force } => {
                 let belt_home = dirs::home_dir()
                     .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?
                     .join(".belt");
-                let ws = claw::ClawWorkspace::init(&belt_home)?;
+                let ws = if force {
+                    claw::ClawWorkspace::init_with_options(&belt_home, true)?
+                } else {
+                    claw::ClawWorkspace::init(&belt_home)?
+                };
                 tracing::info!(path = %ws.path.display(), "claw workspace initialized");
             }
             ClawCommands::Rules => {
@@ -192,6 +205,15 @@ async fn main() -> anyhow::Result<()> {
                 for rule in &rules {
                     println!("{}", rule.display());
                 }
+            }
+            ClawCommands::Edit { rule } => {
+                let belt_home = dirs::home_dir()
+                    .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?
+                    .join(".belt");
+                let ws = claw::ClawWorkspace {
+                    path: belt_home.join("claw-workspace"),
+                };
+                ws.edit_rule(rule.as_deref())?;
             }
             ClawCommands::Session => {
                 tracing::info!("interactive session not yet implemented");


### PR DESCRIPTION
## Summary
- `belt claw init` 시 `commands/`, `skills/gap-detect/`, `skills/prioritize/` 디렉토리 생성
- 기존 사용자 정책 파일 보존 (기본), `--force` 플래그로 덮어쓰기
- `belt claw edit [rule]` 서브커맨드 추가 ($EDITOR 통합)

## Test plan
- [x] `cargo test -p belt-cli` 통과
- [x] init 후 디렉토리 구조 검증
- [x] 기존 파일 보존 / force 덮어쓰기 테스트

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)