### PR TITLE
fix: record_history() 빌드 실패 수정 (source_id/work_id)

### DIFF
--- a/crates/belt-daemon/src/daemon.rs
+++ b/crates/belt-daemon/src/daemon.rs
@@ -441,6 +441,8 @@ impl Daemon {
             .count() as u32
             + 1;
         self.history.push(HistoryEntry {
+            source_id: item.source_id.clone(),
+            work_id: item.work_id.clone(),
             state: item.state.clone(),
             status: status
                 .parse()


### PR DESCRIPTION
## Summary
- `record_history()`의 `HistoryEntry` 초기화에 `source_id`, `work_id` 필드 추가
- PR #36에서 추가된 필드가 daemon에 반영되지 않아 발생한 빌드 실패 수정

## Test plan
- [x] `cargo check -p belt-daemon` 통과

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)