### PR TITLE
chore: Claude Code hooks 설정 (Rust lint + 브랜치 보호)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,15 +9,25 @@
             "command": "if echo \"$TOOL_INPUT\" | grep -q '\"file_path\".*\\.env'; then echo 'BLOCK: .env 파일 수정 금지' >&2; exit 1; fi"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if echo \"$TOOL_INPUT\" | grep -qE 'git\\s+commit'; then branch=$(git -C /Users/irene/Documents/belt-3 rev-parse --abbrev-ref HEAD 2>/dev/null); if [ \"$branch\" = \"main\" ] || [ \"$branch\" = \"master\" ]; then echo 'BLOCK: main/master 브랜치에서 직접 커밋 금지. 별도 브랜치를 사용하세요.' >&2; exit 1; fi; fi"
+          }
+        ]
       }
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit",
+        "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$TOOL_INPUT\" | grep -qE '\"file_path\".*\\.rs\"'; then cd /Users/irene/Documents/belt && cargo check 2>&1 | tail -20; fi"
+            "command": "if echo \"$TOOL_INPUT\" | grep -qE '\"file_path\".*\\.rs\"'; then cd /Users/irene/Documents/belt-3 && cargo check --quiet 2>&1 | head -20; fi",
+            "timeout": 30000
           }
         ]
       }


### PR DESCRIPTION
## Summary
- PostToolUse hook: 프로젝트 경로 수정, `--quiet` 추가, timeout 30초
- PreToolUse hook: main/master 브랜치에서 직접 커밋 차단
- 기존 .env 파일 보호 hook 유지

## Test plan
- [x] .rs 파일 수정 시 `cargo check --quiet` 자동 실행
- [x] main 브랜치에서 git commit 차단

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)