### PR TITLE
feat: token_usage DB에 cache_read/cache_write 컬럼 추가

### DIFF
--- a/crates/belt-core/src/runtime.rs
+++ b/crates/belt-core/src/runtime.rs
@@ -53,8 +53,8 @@ impl RuntimeResponse {
 pub struct TokenUsage {
     pub input_tokens: u64,
     pub output_tokens: u64,
-    pub cache_read_tokens: u64,
-    pub cache_write_tokens: u64,
+    pub cache_read_tokens: Option<u64>,
+    pub cache_write_tokens: Option<u64>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/belt-infra/src/db.rs
+++ b/crates/belt-infra/src/db.rs
@@ -42,6 +42,21 @@ pub struct CronJob {
     pub created_at: DateTime<Utc>,
 }
 
+/// A persisted token usage record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenUsageRow {
+    pub id: i64,
+    pub work_id: String,
+    pub workspace: String,
+    pub runtime: String,
+    pub model: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: Option<u64>,
+    pub cache_write_tokens: Option<u64>,
+    pub created_at: DateTime<Utc>,
+}
+
 /// SQLite-backed persistence for Belt state.
 pub struct Database {
     conn: Connection,
@@ -115,14 +130,16 @@ impl Database {
             );
 
             CREATE TABLE IF NOT EXISTS token_usage (
-                id            INTEGER PRIMARY KEY AUTOINCREMENT,
-                work_id       TEXT NOT NULL,
-                workspace     TEXT NOT NULL,
-                runtime       TEXT NOT NULL,
-                model         TEXT NOT NULL,
-                input_tokens  INTEGER NOT NULL,
-                output_tokens INTEGER NOT NULL,
-                created_at    TEXT NOT NULL
+                id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+                work_id            TEXT NOT NULL,
+                workspace          TEXT NOT NULL,
+                runtime            TEXT NOT NULL,
+                model              TEXT NOT NULL,
+                input_tokens       INTEGER NOT NULL,
+                output_tokens      INTEGER NOT NULL,
+                cache_read_tokens  INTEGER,
+                cache_write_tokens INTEGER,
+                created_at         TEXT NOT NULL
             );
             ",
             )
@@ -483,8 +500,8 @@ impl Database {
         let now = Utc::now().to_rfc3339();
         self.conn
             .execute(
-                "INSERT INTO token_usage (work_id, workspace, runtime, model, input_tokens, output_tokens, created_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                "INSERT INTO token_usage (work_id, workspace, runtime, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
                 params![
                     work_id,
                     workspace,
@@ -492,11 +509,45 @@ impl Database {
                     model,
                     usage.input_tokens as i64,
                     usage.output_tokens as i64,
+                    usage.cache_read_tokens.map(|v| v as i64),
+                    usage.cache_write_tokens.map(|v| v as i64),
                     now,
                 ],
             )
             .map_err(|e| BeltError::Database(e.to_string()))?;
         Ok(())
+    }
+
+    /// Retrieve all token usage records for a given `work_id`.
+    pub fn get_token_usage(&self, work_id: &str) -> Result<Vec<TokenUsageRow>, BeltError> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, work_id, workspace, runtime, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, created_at
+                 FROM token_usage WHERE work_id = ?1 ORDER BY created_at ASC",
+            )
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+
+        let rows = stmt
+            .query_map(params![work_id], |row| {
+                let created: String = row.get(9)?;
+                Ok(TokenUsageRow {
+                    id: row.get(0)?,
+                    work_id: row.get(1)?,
+                    workspace: row.get(2)?,
+                    runtime: row.get(3)?,
+                    model: row.get(4)?,
+                    input_tokens: row.get(5)?,
+                    output_tokens: row.get(6)?,
+                    cache_read_tokens: row.get(7)?,
+                    cache_write_tokens: row.get(8)?,
+                    created_at: parse_datetime(&created),
+                })
+            })
+            .map_err(|e| BeltError::Database(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        Ok(rows)
     }
 }
 
@@ -788,23 +839,43 @@ mod tests {
     // ---- Token Usage -------------------------------------------------------
 
     #[test]
-    fn record_token_usage() {
+    fn record_and_get_token_usage() {
         let db = test_db();
         let usage = TokenUsage {
             input_tokens: 1000,
             output_tokens: 500,
-            cache_read_tokens: 0,
-            cache_write_tokens: 0,
+            cache_read_tokens: Some(200),
+            cache_write_tokens: Some(100),
         };
         db.record_token_usage("w1", "ws1", "claude", "opus-4", &usage)
             .unwrap();
 
-        // Verify by raw query — no public read API for token_usage yet.
-        let count: i64 = db
-            .conn
-            .query_row("SELECT COUNT(*) FROM token_usage", [], |row| row.get(0))
+        let rows = db.get_token_usage("w1").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].input_tokens, 1000);
+        assert_eq!(rows[0].output_tokens, 500);
+        assert_eq!(rows[0].cache_read_tokens, Some(200));
+        assert_eq!(rows[0].cache_write_tokens, Some(100));
+        assert_eq!(rows[0].runtime, "claude");
+        assert_eq!(rows[0].model, "opus-4");
+    }
+
+    #[test]
+    fn record_token_usage_without_cache() {
+        let db = test_db();
+        let usage = TokenUsage {
+            input_tokens: 500,
+            output_tokens: 250,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
+        };
+        db.record_token_usage("w2", "ws1", "claude", "sonnet-4", &usage)
             .unwrap();
-        assert_eq!(count, 1);
+
+        let rows = db.get_token_usage("w2").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].cache_read_tokens, None);
+        assert_eq!(rows[0].cache_write_tokens, None);
     }
 
     // ---- Helpers -----------------------------------------------------------

--- a/crates/belt-infra/src/runtimes/claude.rs
+++ b/crates/belt-infra/src/runtimes/claude.rs
@@ -53,17 +53,15 @@ struct ClaudeUsage {
 
 /// stdout JSON에서 token usage를 파싱한다.
 /// 파싱 실패 시 `(None, None, None, raw_stdout)` 반환 (graceful degradation).
-fn parse_claude_json(
-    stdout: &str,
-) -> (Option<TokenUsage>, Option<String>, Option<String>, String) {
+fn parse_claude_json(stdout: &str) -> (Option<TokenUsage>, Option<String>, Option<String>, String) {
     let parsed: Option<ClaudeJsonOutput> = serde_json::from_str(stdout).ok();
     match parsed {
         Some(output) => {
             let token_usage = output.usage.map(|u| TokenUsage {
                 input_tokens: u.input_tokens,
                 output_tokens: u.output_tokens,
-                cache_read_tokens: u.cache_read_input_tokens,
-                cache_write_tokens: u.cache_creation_input_tokens,
+                cache_read_tokens: Some(u.cache_read_input_tokens),
+                cache_write_tokens: Some(u.cache_creation_input_tokens),
             });
             let result_text = output.result.unwrap_or_default();
             (token_usage, output.model, output.session_id, result_text)
@@ -99,8 +97,7 @@ impl AgentRuntime for ClaudeRuntime {
             Ok(output) => {
                 let raw_stdout = String::from_utf8_lossy(&output.stdout).to_string();
                 let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-                let (token_usage, _model, session_id, result_text) =
-                    parse_claude_json(&raw_stdout);
+                let (token_usage, _model, session_id, result_text) = parse_claude_json(&raw_stdout);
 
                 RuntimeResponse {
                     exit_code: output.status.code().unwrap_or(-1),
@@ -150,8 +147,8 @@ mod tests {
         let usage = usage.unwrap();
         assert_eq!(usage.input_tokens, 100);
         assert_eq!(usage.output_tokens, 50);
-        assert_eq!(usage.cache_read_tokens, 10);
-        assert_eq!(usage.cache_write_tokens, 5);
+        assert_eq!(usage.cache_read_tokens, Some(10));
+        assert_eq!(usage.cache_write_tokens, Some(5));
     }
 
     #[test]
@@ -184,7 +181,7 @@ mod tests {
         let usage = usage.unwrap();
         assert_eq!(usage.input_tokens, 200);
         assert_eq!(usage.output_tokens, 100);
-        assert_eq!(usage.cache_read_tokens, 0);
-        assert_eq!(usage.cache_write_tokens, 0);
+        assert_eq!(usage.cache_read_tokens, Some(0));
+        assert_eq!(usage.cache_write_tokens, Some(0));
     }
 }


### PR DESCRIPTION
## Summary
- `TokenUsage`에 `cache_read_tokens`, `cache_write_tokens` (Option<u64>) 추가
- DB 스키마에 cache 컬럼 추가, `record_token_usage()` 확장
- `TokenUsageRow` struct + `get_token_usage()` read API

## Test plan
- [x] `cargo test -p belt-infra` 통과
- [x] cache Some/None 양쪽 테스트

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)