### PR TITLE
fix: 다중 prompt handler chain에서 token usage 누적 합산

### DIFF
--- a/crates/belt-daemon/src/executor.rs
+++ b/crates/belt-daemon/src/executor.rs
@@ -39,19 +39,44 @@ impl ActionExecutor {
         Self { registry }
     }
 
+    /// Execute all actions sequentially, accumulating token usage across the chain.
+    ///
+    /// If any action fails (non-zero exit code), execution stops and the failed
+    /// result is returned with accumulated token usage up to that point.
     pub async fn execute_all(
         &self,
         actions: &[Action],
         env: &ActionEnv,
     ) -> Result<Option<ActionResult>> {
+        let mut total_usage = TokenUsage::default();
+        let mut has_usage = false;
         let mut last_result = None;
+
         for action in actions {
             let result = self.execute_one(action, env).await?;
-            if !result.success() {
-                return Ok(Some(result));
+            if let Some(usage) = &result.token_usage {
+                total_usage.input_tokens += usage.input_tokens;
+                total_usage.output_tokens += usage.output_tokens;
+                if let Some(v) = usage.cache_read_tokens {
+                    *total_usage.cache_read_tokens.get_or_insert(0) += v;
+                }
+                if let Some(v) = usage.cache_write_tokens {
+                    *total_usage.cache_write_tokens.get_or_insert(0) += v;
+                }
+                has_usage = true;
             }
+            let failed = !result.success();
             last_result = Some(result);
+            if failed {
+                break;
+            }
         }
+
+        // Attach accumulated token usage to the final result.
+        if let Some(ref mut result) = last_result {
+            result.token_usage = if has_usage { Some(total_usage) } else { None };
+        }
+
         Ok(last_result)
     }
 
@@ -210,5 +235,95 @@ mod tests {
         let executor = ActionExecutor::new(setup_registry());
         let result = executor.execute_all(&[], &test_env()).await.unwrap();
         assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn execute_all_accumulates_token_usage() {
+        use belt_core::runtime::TokenUsage;
+
+        let mock = MockRuntime::new("mock", vec![0, 0, 0]).with_token_usages(vec![
+            TokenUsage {
+                input_tokens: 100,
+                output_tokens: 50,
+                cache_read_tokens: Some(10),
+                cache_write_tokens: Some(5),
+            },
+            TokenUsage {
+                input_tokens: 200,
+                output_tokens: 80,
+                cache_read_tokens: Some(20),
+                cache_write_tokens: Some(10),
+            },
+            TokenUsage {
+                input_tokens: 150,
+                output_tokens: 60,
+                cache_read_tokens: Some(15),
+                cache_write_tokens: Some(8),
+            },
+        ]);
+        let mut registry = RuntimeRegistry::new("mock".to_string());
+        registry.register(Arc::new(mock));
+        let executor = ActionExecutor::new(Arc::new(registry));
+
+        let actions = vec![
+            Action::prompt("first"),
+            Action::prompt("second"),
+            Action::prompt("third"),
+        ];
+        let result = executor
+            .execute_all(&actions, &test_env())
+            .await
+            .unwrap()
+            .unwrap();
+
+        let usage = result
+            .token_usage
+            .expect("should have accumulated token usage");
+        assert_eq!(usage.input_tokens, 450);
+        assert_eq!(usage.output_tokens, 190);
+        assert_eq!(usage.cache_read_tokens, Some(45));
+        assert_eq!(usage.cache_write_tokens, Some(23));
+    }
+
+    #[tokio::test]
+    async fn execute_all_accumulates_usage_on_failure() {
+        use belt_core::runtime::TokenUsage;
+
+        let mock = MockRuntime::new("mock", vec![0, 1]).with_token_usages(vec![
+            TokenUsage {
+                input_tokens: 100,
+                output_tokens: 50,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
+            },
+            TokenUsage {
+                input_tokens: 200,
+                output_tokens: 80,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
+            },
+        ]);
+        let mut registry = RuntimeRegistry::new("mock".to_string());
+        registry.register(Arc::new(mock));
+        let executor = ActionExecutor::new(Arc::new(registry));
+
+        let actions = vec![
+            Action::prompt("first"),
+            Action::prompt("second"),
+            Action::prompt("third"),
+        ];
+        let result = executor
+            .execute_all(&actions, &test_env())
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Should stop at second action (failure) but still accumulate both usages.
+        assert!(!result.success());
+        let usage = result
+            .token_usage
+            .expect("should have accumulated token usage");
+        assert_eq!(usage.input_tokens, 300);
+        assert_eq!(usage.output_tokens, 130);
     }
 }

--- a/crates/belt-infra/src/runtimes/mock.rs
+++ b/crates/belt-infra/src/runtimes/mock.rs
@@ -3,13 +3,17 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 
-use belt_core::runtime::{AgentRuntime, RuntimeCapabilities, RuntimeRequest, RuntimeResponse};
+use belt_core::runtime::{
+    AgentRuntime, RuntimeCapabilities, RuntimeRequest, RuntimeResponse, TokenUsage,
+};
 
 /// 테스트용 MockRuntime.
 pub struct MockRuntime {
     rt_name: String,
     exit_codes: Mutex<Vec<i32>>,
     calls: Mutex<Vec<String>>,
+    /// Per-invocation token usage. If empty, no token usage is reported.
+    token_usages: Mutex<Vec<TokenUsage>>,
 }
 
 impl MockRuntime {
@@ -18,11 +22,18 @@ impl MockRuntime {
             rt_name: name.to_string(),
             exit_codes: Mutex::new(exit_codes),
             calls: Mutex::new(Vec::new()),
+            token_usages: Mutex::new(Vec::new()),
         }
     }
 
     pub fn always_ok(name: &str) -> Self {
         Self::new(name, vec![])
+    }
+
+    /// Configure per-invocation token usage responses.
+    pub fn with_token_usages(self, usages: Vec<TokenUsage>) -> Self {
+        *self.token_usages.lock().unwrap() = usages;
+        self
     }
 
     pub fn calls(&self) -> Vec<String> {
@@ -44,12 +55,21 @@ impl AgentRuntime for MockRuntime {
             if codes.is_empty() { 0 } else { codes.remove(0) }
         };
 
+        let token_usage = {
+            let mut usages = self.token_usages.lock().unwrap();
+            if usages.is_empty() {
+                None
+            } else {
+                Some(usages.remove(0))
+            }
+        };
+
         RuntimeResponse {
             exit_code,
             stdout: format!("mock response for: {}", request.prompt),
             stderr: String::new(),
             duration: Duration::from_millis(100),
-            token_usage: None,
+            token_usage,
             session_id: None,
         }
     }


### PR DESCRIPTION
## Summary
- `execute_all()`이 모든 action의 token usage를 누적 합산
- 실패 시에도 그 시점까지의 사용량 보존
- MockRuntime에 per-invocation token usage 설정 추가

## Test plan
- [x] `cargo test -p belt-daemon` 통과
- [x] 3-prompt chain 누적 테스트
- [x] 중간 실패 시 부분 누적 테스트

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)