### PR TITLE
fix: on_enter 비정상 exit code 처리 추가

### DIFF
--- a/crates/belt-daemon/src/daemon.rs
+++ b/crates/belt-daemon/src/daemon.rs
@@ -163,26 +163,48 @@ impl Daemon {
 
         // on_enter
         let on_enter: Vec<Action> = state_config.on_enter.iter().map(Action::from).collect();
-        if let Err(e) = self.executor.execute_all(&on_enter, &env).await {
-            // 1. Record failure
-            self.record_history(item, "failed", Some(&e.to_string()));
-            // 2. Count failures and resolve escalation
-            let failure_count = self.count_failures(&item.source_id, &item.state);
-            let escalation = self.resolve_escalation(&item.state, failure_count);
-            // 3. Run on_fail if needed
-            if escalation.should_run_on_fail() {
-                let on_fail: Vec<Action> = state_config.on_fail.iter().map(Action::from).collect();
-                let _ = self.executor.execute_all(&on_fail, &env).await;
-            }
-            // 4. Apply escalation (retry/hitl/skip)
-            self.handle_escalation(item, escalation);
-            self.tracker.release(&self.config.name.clone());
+        match self.executor.execute_all(&on_enter, &env).await {
+            Ok(Some(r)) if !r.success() => {
+                // 비정상 exit code → escalation 적용
+                self.record_history(item, "failed", Some(&r.stderr));
+                let failure_count = self.count_failures(&item.source_id, &item.state);
+                let escalation = self.resolve_escalation(&item.state, failure_count);
+                if escalation.should_run_on_fail() {
+                    let on_fail: Vec<Action> =
+                        state_config.on_fail.iter().map(Action::from).collect();
+                    let _ = self.executor.execute_all(&on_fail, &env).await;
+                }
+                self.handle_escalation(item, escalation);
+                self.tracker.release(&self.config.name.clone());
 
-            return ItemOutcome::Failed {
-                item: item.clone(),
-                error: format!("on_enter failed: {e}"),
-                escalation,
-            };
+                return ItemOutcome::Failed {
+                    item: item.clone(),
+                    error: format!("on_enter failed with exit code {}", r.exit_code),
+                    escalation,
+                };
+            }
+            Err(e) => {
+                // 실행 자체가 실패한 경우
+                self.record_history(item, "failed", Some(&e.to_string()));
+                let failure_count = self.count_failures(&item.source_id, &item.state);
+                let escalation = self.resolve_escalation(&item.state, failure_count);
+                if escalation.should_run_on_fail() {
+                    let on_fail: Vec<Action> =
+                        state_config.on_fail.iter().map(Action::from).collect();
+                    let _ = self.executor.execute_all(&on_fail, &env).await;
+                }
+                self.handle_escalation(item, escalation);
+                self.tracker.release(&self.config.name.clone());
+
+                return ItemOutcome::Failed {
+                    item: item.clone(),
+                    error: format!("on_enter failed: {e}"),
+                    escalation,
+                };
+            }
+            _ => {
+                // 성공 → handler 진행
+            }
         }
 
         // handler chain
@@ -441,6 +463,8 @@ impl Daemon {
             .count() as u32
             + 1;
         self.history.push(HistoryEntry {
+            source_id: item.source_id.clone(),
+            work_id: item.work_id.clone(),
             state: item.state.clone(),
             status: status
                 .parse()


### PR DESCRIPTION
## Summary
- on_enter 실행 결과를 `match`로 변경: `Err` + `Ok(!success)` 모두 escalation 적용
- 비정상 exit code가 조용히 무시되던 문제 수정

## Test plan
- [x] `cargo test -p belt-daemon` — 21/21 통과
- [x] `cargo clippy -- -D warnings` 통과

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)