### PR TITLE
feat(daemon): integrate main loop, evaluate concurrency, and force_trigger

### DIFF
--- a/crates/belt-cli/src/main.rs
+++ b/crates/belt-cli/src/main.rs
@@ -1,7 +1,17 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
 use clap::{Parser, Subcommand};
 
 mod agent;
 mod bootstrap;
+
+use belt_core::runtime::RuntimeRegistry;
+use belt_daemon::daemon::Daemon;
+use belt_infra::runtimes::claude::ClaudeRuntime;
+use belt_infra::sources::github::GitHubDataSource;
+use belt_infra::worktree::GitWorktreeManager;
+
 mod claw;
 mod dashboard;
 mod status;
@@ -20,7 +30,17 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Start the daemon.
-    Start,
+    Start {
+        /// Path to workspace.yaml config.
+        #[arg(long, default_value = "workspace.yaml")]
+        config: String,
+        /// Tick interval in seconds.
+        #[arg(long, default_value_t = 30)]
+        tick: u64,
+        /// Maximum concurrent tasks.
+        #[arg(long, default_value_t = 4)]
+        max_concurrent: u32,
+    },
     /// Stop the daemon.
     Stop,
     /// Show system status.
@@ -230,6 +250,64 @@ enum SpecCommands {
     },
 }
 
+/// Load workspace config and start the daemon loop.
+async fn start_daemon(
+    config_path: &str,
+    tick_interval_secs: u64,
+    max_concurrent: u32,
+) -> anyhow::Result<()> {
+    let config_content = std::fs::read_to_string(config_path)
+        .map_err(|e| anyhow::anyhow!("failed to read config file '{}': {}", config_path, e))?;
+    let config: belt_core::workspace::WorkspaceConfig = serde_yaml::from_str(&config_content)
+        .map_err(|e| anyhow::anyhow!("failed to parse config file '{}': {}", config_path, e))?;
+
+    let belt_home = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?
+        .join(".belt");
+
+    // Build DataSources from workspace config.
+    let mut sources: Vec<Box<dyn belt_core::source::DataSource>> = Vec::new();
+    for (name, source_config) in &config.sources {
+        if name == "github" || source_config.url.contains("github.com") {
+            sources.push(Box::new(GitHubDataSource::new(&source_config.url)));
+        }
+    }
+
+    // Runtime registry with Claude as default.
+    let mut registry = RuntimeRegistry::new("claude".to_string());
+    registry.register(Arc::new(ClaudeRuntime::new(None)));
+
+    // Worktree manager.
+    let worktree_base = belt_home.join("worktrees");
+    std::fs::create_dir_all(&worktree_base)?;
+    let repo_path = PathBuf::from(".");
+    let worktree_mgr = GitWorktreeManager::new(worktree_base, repo_path);
+
+    // Database for token usage.
+    let db_path = belt_home.join("belt.db");
+    std::fs::create_dir_all(&belt_home)?;
+    let db = belt_infra::db::Database::open(db_path.to_str().unwrap_or("belt.db"))
+        .map_err(|e| anyhow::anyhow!("failed to open database: {e}"))?;
+
+    let mut daemon = Daemon::new(
+        config,
+        sources,
+        Arc::new(registry),
+        Box::new(worktree_mgr),
+        max_concurrent,
+    )
+    .with_db(db)
+    .with_belt_home(belt_home);
+
+    tracing::info!(
+        "starting belt daemon (tick={}s, max_concurrent={})",
+        tick_interval_secs,
+        max_concurrent
+    );
+    daemon.run(tick_interval_secs).await;
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
@@ -241,9 +319,12 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Start => {
-            tracing::info!("starting belt daemon...");
-            // TODO: daemon start
+        Commands::Start {
+            config,
+            tick,
+            max_concurrent,
+        } => {
+            start_daemon(&config, tick, max_concurrent).await?;
         }
         Commands::Stop => {
             tracing::info!("stopping belt daemon...");

--- a/crates/belt-daemon/src/concurrency.rs
+++ b/crates/belt-daemon/src/concurrency.rs
@@ -4,10 +4,15 @@ use std::collections::HashMap;
 ///
 /// Level 1: workspace별 제한 (workspace.concurrency)
 /// Level 2: 전역 제한 (daemon.max_concurrent)
+///
+/// evaluate LLM 호출도 concurrency slot을 소비한다.
+/// `active_evaluates` 카운트가 `total`에 포함되어 전역 제한을 공유한다.
 pub struct ConcurrencyTracker {
     per_workspace: HashMap<String, usize>,
     total: usize,
     max_total: usize,
+    /// 현재 실행 중인 evaluate LLM 호출 수. `total`에 포함된다.
+    active_evaluates: usize,
 }
 
 impl ConcurrencyTracker {
@@ -16,6 +21,7 @@ impl ConcurrencyTracker {
             per_workspace: HashMap::new(),
             total: 0,
             max_total: max_total as usize,
+            active_evaluates: 0,
         }
     }
 
@@ -57,6 +63,23 @@ impl ConcurrencyTracker {
             }
         }
         self.total = self.total.saturating_sub(1);
+    }
+
+    /// Track an evaluate LLM call. Consumes a global concurrency slot.
+    pub fn track_evaluate(&mut self) {
+        self.active_evaluates += 1;
+        self.total += 1;
+    }
+
+    /// Release an evaluate LLM call slot.
+    pub fn release_evaluate(&mut self) {
+        self.active_evaluates = self.active_evaluates.saturating_sub(1);
+        self.total = self.total.saturating_sub(1);
+    }
+
+    /// Number of active evaluate LLM calls.
+    pub fn active_evaluate_count(&self) -> usize {
+        self.active_evaluates
     }
 
     pub fn total(&self) -> usize {
@@ -115,6 +138,43 @@ mod tests {
     fn release_saturating() {
         let mut tracker = ConcurrencyTracker::new(4);
         tracker.release("ws1");
+        assert_eq!(tracker.total(), 0);
+    }
+
+    #[test]
+    fn evaluate_consumes_global_slot() {
+        let mut tracker = ConcurrencyTracker::new(2);
+        tracker.track_evaluate();
+        assert_eq!(tracker.total(), 1);
+        assert_eq!(tracker.active_evaluate_count(), 1);
+        assert!(tracker.can_spawn());
+
+        tracker.track_evaluate();
+        assert_eq!(tracker.total(), 2);
+        assert!(!tracker.can_spawn());
+    }
+
+    #[test]
+    fn evaluate_and_handler_share_slots() {
+        let mut tracker = ConcurrencyTracker::new(3);
+        tracker.track("ws1");
+        tracker.track_evaluate();
+        assert_eq!(tracker.total(), 2);
+        assert!(tracker.can_spawn());
+
+        tracker.track("ws2");
+        assert!(!tracker.can_spawn());
+
+        tracker.release_evaluate();
+        assert!(tracker.can_spawn());
+        assert_eq!(tracker.active_evaluate_count(), 0);
+    }
+
+    #[test]
+    fn release_evaluate_saturating() {
+        let mut tracker = ConcurrencyTracker::new(4);
+        tracker.release_evaluate();
+        assert_eq!(tracker.active_evaluate_count(), 0);
         assert_eq!(tracker.total(), 0);
     }
 }

--- a/crates/belt-daemon/src/daemon.rs
+++ b/crates/belt-daemon/src/daemon.rs
@@ -669,6 +669,16 @@ impl Daemon {
             return;
         }
 
+        // evaluate LLM 호출도 concurrency slot을 소비한다 (D-04).
+        if !self.tracker.can_spawn() {
+            tracing::debug!(
+                "no concurrency slots available for evaluate, deferring {} items",
+                completed.len()
+            );
+            return;
+        }
+        self.tracker.track_evaluate();
+
         // Evaluator 스크립트 실행으로 Done vs HITL 판정.
         let eval_result = self.evaluator.run_evaluate(&self.belt_home).await;
 
@@ -723,6 +733,9 @@ impl Daemon {
                 );
             }
         }
+
+        // evaluate slot 반환.
+        self.tracker.release_evaluate();
     }
 
     /// Daemon tick: collect -> advance -> execute -> evaluate.
@@ -743,9 +756,13 @@ impl Daemon {
         }
 
         let outcomes = self.execute_running().await;
+        let mut has_completed = false;
         for outcome in &outcomes {
             match outcome {
-                ItemOutcome::Completed(item) => tracing::info!("completed: {}", item.work_id),
+                ItemOutcome::Completed(item) => {
+                    tracing::info!("completed: {}", item.work_id);
+                    has_completed = true;
+                }
                 ItemOutcome::Failed {
                     item,
                     error,
@@ -761,6 +778,16 @@ impl Daemon {
                 ItemOutcome::Skipped(item) => tracing::info!("skipped: {}", item.work_id),
             }
         }
+
+        // handler 성공 → Completed 전이 후 force_trigger("evaluate") (D-10).
+        // force_trigger는 cron의 last_run_at을 리셋하여 다음 tick에서 즉시 실행.
+        if has_completed {
+            self.cron_engine.force_trigger("evaluate");
+            tracing::debug!("force_trigger(evaluate) after handler completion");
+        }
+
+        // Cron engine tick (evaluate, HITL timeout, etc.).
+        self.cron_engine.tick();
 
         // Evaluator로 Completed 아이템 평가 (Done vs HITL).
         self.evaluate_completed().await;


### PR DESCRIPTION
Closes #57

## Summary
- Wire `belt start` CLI command to daemon run loop with config/tick/max-concurrent args
- Add evaluate concurrency tracking to ConcurrencyTracker (slots shared with handlers)
- Auto-trigger evaluate cron after handler completion via force_trigger()
- Integrate CronEngine as Daemon field, ticked each cycle

## Test plan
- [ ] cargo check -p belt-daemon -p belt-cli
- [ ] cargo test -p belt-daemon (49 tests)
- [ ] Manual: belt start --config workspace.yml

Generated with Claude Code