### PR TITLE
feat(infra): complete GitHub DataSource context schema and on_fail integration

### DIFF
--- a/crates/belt-cli/src/main.rs
+++ b/crates/belt-cli/src/main.rs
@@ -169,9 +169,70 @@ async fn main() -> anyhow::Result<()> {
                 tracing::info!(work_id, "skipping item...");
             }
         },
-        Commands::Context { work_id, json: _ } => {
-            tracing::info!(work_id, "fetching context...");
-            // TODO: context retrieval
+        Commands::Context { work_id, json } => {
+            let db_path = dirs::home_dir()
+                .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?
+                .join(".belt")
+                .join("belt.db");
+
+            if !db_path.exists() {
+                anyhow::bail!("belt database not found at {}", db_path.display());
+            }
+
+            let db_path_str = db_path.to_string_lossy();
+            let db = belt_infra::db::Database::open(&db_path_str)?;
+            let item = db.get_item(&work_id)?;
+
+            // Convert DB HistoryEvents to context HistoryEntries.
+            let history_events = db.get_history(&item.source_id)?;
+            let history: Vec<belt_core::context::HistoryEntry> = history_events
+                .iter()
+                .map(|e| belt_core::context::HistoryEntry {
+                    source_id: e.source_id.clone(),
+                    work_id: e.work_id.clone(),
+                    state: e.state.clone(),
+                    status: e
+                        .status
+                        .parse()
+                        .unwrap_or(belt_core::context::HistoryStatus::Failed),
+                    attempt: e.attempt as u32,
+                    summary: e.summary.clone(),
+                    error: e.error.clone(),
+                    created_at: e.created_at.clone(),
+                })
+                .collect();
+
+            let ctx = belt_core::context::ItemContext {
+                work_id: item.work_id.clone(),
+                workspace: item.workspace_id.clone(),
+                queue: belt_core::context::QueueContext {
+                    phase: item.phase.as_str().to_string(),
+                    state: item.state.clone(),
+                    source_id: item.source_id.clone(),
+                },
+                source: belt_core::context::SourceContext {
+                    source_type: "github".to_string(),
+                    url: String::new(),
+                    default_branch: None,
+                },
+                issue: None,
+                pr: None,
+                history,
+                worktree: None,
+            };
+
+            if json {
+                println!("{}", serde_json::to_string_pretty(&ctx)?);
+            } else {
+                println!("work_id:   {}", ctx.work_id);
+                println!("workspace: {}", ctx.workspace);
+                println!("phase:     {}", ctx.queue.phase);
+                println!("state:     {}", ctx.queue.state);
+                println!("source_id: {}", ctx.queue.source_id);
+                if !ctx.history.is_empty() {
+                    println!("history:   {} entries", ctx.history.len());
+                }
+            }
         }
         Commands::Agent { workspace, prompt } => {
             if let Some(name) = &workspace {

--- a/crates/belt-core/src/context.rs
+++ b/crates/belt-core/src/context.rs
@@ -109,8 +109,36 @@ pub struct PrContext {
     pub number: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub head_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub review_comments: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub commits: Vec<CommitContext>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub files: Vec<FileChangeContext>,
+}
+
+/// PR에 포함된 커밋 요약.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitContext {
+    pub sha: String,
+    pub message: String,
+    pub author: String,
+}
+
+/// PR에서 변경된 파일 정보.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileChangeContext {
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additions: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deletions: Option<u64>,
 }
 
 impl ItemContext {

--- a/crates/belt-daemon/src/daemon.rs
+++ b/crates/belt-daemon/src/daemon.rs
@@ -282,6 +282,18 @@ impl Daemon {
             match result {
                 Ok(exec_result) => {
                     let outcome = self.apply_execution_result(exec_result);
+
+                    // Execute on_fail scripts based on escalation policy.
+                    if let ItemOutcome::Failed {
+                        ref item,
+                        escalation,
+                        ..
+                    } = outcome
+                        && escalation.should_run_on_fail()
+                    {
+                        self.execute_on_fail_for_item(item).await;
+                    }
+
                     outcomes.push(outcome);
                 }
                 Err(e) => {
@@ -291,6 +303,35 @@ impl Daemon {
         }
 
         outcomes
+    }
+
+    /// Execute on_fail scripts for a failed item (best-effort).
+    ///
+    /// Escalation policy의 `should_run_on_fail()`이 true일 때만 호출된다.
+    /// silent retry는 on_fail을 실행하지 않는다.
+    async fn execute_on_fail_for_item(&self, item: &QueueItem) {
+        let state_config = match self.find_state_config(&item.state).cloned() {
+            Some(cfg) => cfg,
+            None => return,
+        };
+
+        if state_config.on_fail.is_empty() {
+            return;
+        }
+
+        let worktree = match self.worktree_mgr.create_or_reuse(&item.work_id) {
+            Ok(path) => path,
+            Err(e) => {
+                tracing::warn!("on_fail worktree error for {}: {e}", item.work_id);
+                return;
+            }
+        };
+
+        let env = ActionEnv::new(&item.work_id, &worktree);
+        let on_fail: Vec<Action> = state_config.on_fail.iter().map(Action::from).collect();
+        if let Err(e) = self.executor.execute_all(&on_fail, &env).await {
+            tracing::warn!("on_fail execution error for {}: {e}", item.work_id);
+        }
     }
 
     /// 단일 아이템의 handler를 실행하는 순수 async 함수.
@@ -334,10 +375,6 @@ impl Daemon {
         let on_enter: Vec<Action> = state_config.on_enter.iter().map(Action::from).collect();
         match executor.execute_all(&on_enter, &env).await {
             Ok(Some(r)) if !r.success() => {
-                // on_fail 스크립트 실행 시도 (best-effort).
-                let on_fail: Vec<Action> = state_config.on_fail.iter().map(Action::from).collect();
-                let _ = executor.execute_all(&on_fail, &env).await;
-
                 item.phase = QueuePhase::Failed;
                 return ExecutionResult {
                     item,
@@ -350,9 +387,6 @@ impl Daemon {
             }
             Err(e) => {
                 tracing::warn!("on_enter failed for {}: {e}", item.work_id);
-                let on_fail: Vec<Action> = state_config.on_fail.iter().map(Action::from).collect();
-                let _ = executor.execute_all(&on_fail, &env).await;
-
                 item.phase = QueuePhase::Failed;
                 return ExecutionResult {
                     item,

--- a/crates/belt-infra/src/db.rs
+++ b/crates/belt-infra/src/db.rs
@@ -683,20 +683,22 @@ impl Database {
             .map_err(|e| BeltError::Database(e.to_string()))?;
 
         rows.into_iter()
-            .map(|(wid, ws, rt, model, input, output, cache_read, cache_write, dur, created)| {
-                Ok(TokenUsageRow {
-                    work_id: wid,
-                    workspace: ws,
-                    runtime: rt,
-                    model,
-                    input_tokens: input as u64,
-                    output_tokens: output as u64,
-                    cache_read_tokens: cache_read.map(|v| v as u64),
-                    cache_write_tokens: cache_write.map(|v| v as u64),
-                    duration_ms: dur.map(|d| d as u64),
-                    created_at: parse_datetime(&created)?,
-                })
-            })
+            .map(
+                |(wid, ws, rt, model, input, output, cache_read, cache_write, dur, created)| {
+                    Ok(TokenUsageRow {
+                        work_id: wid,
+                        workspace: ws,
+                        runtime: rt,
+                        model,
+                        input_tokens: input as u64,
+                        output_tokens: output as u64,
+                        cache_read_tokens: cache_read.map(|v| v as u64),
+                        cache_write_tokens: cache_write.map(|v| v as u64),
+                        duration_ms: dur.map(|d| d as u64),
+                        created_at: parse_datetime(&created)?,
+                    })
+                },
+            )
             .collect()
     }
 
@@ -739,20 +741,22 @@ impl Database {
             .map_err(|e| BeltError::Database(e.to_string()))?;
 
         rows.into_iter()
-            .map(|(wid, ws, rt, model, input, output, cache_read, cache_write, dur, created)| {
-                Ok(TokenUsageRow {
-                    work_id: wid,
-                    workspace: ws,
-                    runtime: rt,
-                    model,
-                    input_tokens: input as u64,
-                    output_tokens: output as u64,
-                    cache_read_tokens: cache_read.map(|v| v as u64),
-                    cache_write_tokens: cache_write.map(|v| v as u64),
-                    duration_ms: dur.map(|d| d as u64),
-                    created_at: parse_datetime(&created)?,
-                })
-            })
+            .map(
+                |(wid, ws, rt, model, input, output, cache_read, cache_write, dur, created)| {
+                    Ok(TokenUsageRow {
+                        work_id: wid,
+                        workspace: ws,
+                        runtime: rt,
+                        model,
+                        input_tokens: input as u64,
+                        output_tokens: output as u64,
+                        cache_read_tokens: cache_read.map(|v| v as u64),
+                        cache_write_tokens: cache_write.map(|v| v as u64),
+                        duration_ms: dur.map(|d| d as u64),
+                        created_at: parse_datetime(&created)?,
+                    })
+                },
+            )
             .collect()
     }
 }

--- a/crates/belt-infra/src/sources/github.rs
+++ b/crates/belt-infra/src/sources/github.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 use async_trait::async_trait;
 
-use belt_core::context::{IssueContext, ItemContext, PrContext, QueueContext, SourceContext};
+use belt_core::context::{
+    CommitContext, FileChangeContext, IssueContext, ItemContext, PrContext, QueueContext,
+    SourceContext,
+};
 use belt_core::phase::QueuePhase;
 use belt_core::queue::QueueItem;
 use belt_core::source::DataSource;
@@ -76,7 +79,8 @@ impl GitHubDataSource {
 
     /// `gh` CLI로 해당 이슈에 연결된 PR을 조회한다.
     ///
-    /// `gh pr list`에서 현재 이슈 번호와 연결된 PR을 찾는다.
+    /// `gh pr list`에서 현재 이슈 번호와 연결된 PR을 찾고,
+    /// 리뷰 코멘트, 커밋 목록, 파일 변경사항을 함께 조회한다.
     async fn fetch_linked_pr(repo: &str, issue_number: i64) -> Option<PrContext> {
         let output = tokio::process::Command::new("gh")
             .args([
@@ -101,12 +105,142 @@ impl GitHubDataSource {
 
         let number = pr["number"].as_i64()?;
         let head_branch = pr["headRefName"].as_str().map(|s| s.to_string());
+        let title = pr["title"].as_str().map(|s| s.to_string());
+        let state = pr["state"].as_str().map(|s| s.to_string());
+        let url = pr["url"].as_str().map(|s| s.to_string());
+
+        // 리뷰 코멘트, 커밋, 파일 변경사항을 병렬로 조회
+        let (reviews, commits, files) = tokio::join!(
+            Self::fetch_pr_reviews(repo, number),
+            Self::fetch_pr_commits(repo, number),
+            Self::fetch_pr_files(repo, number),
+        );
 
         Some(PrContext {
             number,
             head_branch,
-            review_comments: vec![],
+            title,
+            state,
+            url,
+            review_comments: reviews.unwrap_or_default(),
+            commits: commits.unwrap_or_default(),
+            files: files.unwrap_or_default(),
         })
+    }
+
+    /// `gh` CLI로 PR의 리뷰 코멘트를 조회한다.
+    async fn fetch_pr_reviews(repo: &str, pr_number: i64) -> Option<Vec<String>> {
+        let output = tokio::process::Command::new("gh")
+            .args([
+                "pr",
+                "view",
+                &pr_number.to_string(),
+                "--repo",
+                repo,
+                "--json",
+                "reviews",
+            ])
+            .output()
+            .await;
+
+        let output = output.ok().filter(|o| o.status.success())?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let val: serde_json::Value = serde_json::from_str(&stdout).ok()?;
+
+        let reviews = val["reviews"].as_array()?;
+        let comments: Vec<String> = reviews
+            .iter()
+            .filter_map(|r| r["body"].as_str())
+            .filter(|body| !body.is_empty())
+            .map(|s| s.to_string())
+            .collect();
+
+        Some(comments)
+    }
+
+    /// `gh` CLI로 PR의 커밋 목록을 조회한다.
+    async fn fetch_pr_commits(repo: &str, pr_number: i64) -> Option<Vec<CommitContext>> {
+        let output = tokio::process::Command::new("gh")
+            .args([
+                "pr",
+                "view",
+                &pr_number.to_string(),
+                "--repo",
+                repo,
+                "--json",
+                "commits",
+            ])
+            .output()
+            .await;
+
+        let output = output.ok().filter(|o| o.status.success())?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let val: serde_json::Value = serde_json::from_str(&stdout).ok()?;
+
+        let commits = val["commits"].as_array()?;
+        let result: Vec<CommitContext> = commits
+            .iter()
+            .filter_map(|c| {
+                let sha = c["oid"].as_str().unwrap_or_default().to_string();
+                let message = c["messageHeadline"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string();
+                let author = c["authors"]
+                    .as_array()
+                    .and_then(|a| a.first())
+                    .and_then(|a| a["login"].as_str().or_else(|| a["name"].as_str()))
+                    .unwrap_or_default()
+                    .to_string();
+                if sha.is_empty() {
+                    return None;
+                }
+                Some(CommitContext {
+                    sha,
+                    message,
+                    author,
+                })
+            })
+            .collect();
+
+        Some(result)
+    }
+
+    /// `gh` CLI로 PR의 파일 변경사항을 조회한다.
+    async fn fetch_pr_files(repo: &str, pr_number: i64) -> Option<Vec<FileChangeContext>> {
+        let output = tokio::process::Command::new("gh")
+            .args([
+                "pr",
+                "view",
+                &pr_number.to_string(),
+                "--repo",
+                repo,
+                "--json",
+                "files",
+            ])
+            .output()
+            .await;
+
+        let output = output.ok().filter(|o| o.status.success())?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let val: serde_json::Value = serde_json::from_str(&stdout).ok()?;
+
+        let files = val["files"].as_array()?;
+        let result: Vec<FileChangeContext> = files
+            .iter()
+            .filter_map(|f| {
+                let path = f["path"].as_str()?.to_string();
+                let additions = f["additions"].as_u64();
+                let deletions = f["deletions"].as_u64();
+                Some(FileChangeContext {
+                    path,
+                    additions,
+                    deletions,
+                })
+            })
+            .collect();
+
+        Some(result)
     }
 
     /// `gh repo view`로 기본 브랜치를 조회한다.


### PR DESCRIPTION
Closes #61

## Summary
- Extend PrContext with title, state, url, commits, files fields
- Add CommitContext and FileChangeContext types to belt-core
- Implement fetch_pr_reviews/commits/files in GitHubDataSource (parallel via tokio::join!)
- Wire `belt context --json` CLI command (was TODO stub)
- Connect on_fail conditional execution in daemon (gated by should_run_on_fail())

## Test plan
- [ ] cargo check -p belt-infra -p belt-cli -p belt-daemon
- [ ] cargo test -p belt-infra
- [ ] Manual: belt context --json <work_id>

🤖 Generated with [Claude Code](https://claude.com/claude-code)