### PR TITLE
feat(workspace): implement onboarding flow with DB persistence and cron seeding

### DIFF
--- a/crates/belt-cli/src/main.rs
+++ b/crates/belt-cli/src/main.rs
@@ -141,17 +141,75 @@ async fn main() -> anyhow::Result<()> {
             tracing::info!(format, "showing status...");
             // TODO: status display
         }
-        Commands::Workspace { command } => match command {
-            WorkspaceCommands::Add { config } => {
-                tracing::info!(config, "registering workspace...");
+        Commands::Workspace { command } => {
+            let belt_home = dirs::home_dir()
+                .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?
+                .join(".belt");
+            std::fs::create_dir_all(&belt_home)?;
+            let db_path = belt_home.join("belt.db");
+            let db = belt_infra::db::Database::open(
+                db_path
+                    .to_str()
+                    .ok_or_else(|| anyhow::anyhow!("invalid db path"))?,
+            )?;
+
+            match command {
+                WorkspaceCommands::Add { config } => {
+                    let config_path = std::path::Path::new(&config);
+                    let result = belt_infra::onboarding::onboard_workspace(&db, config_path)?;
+
+                    // Initialize claw workspace automatically
+                    let claw_ws = claw::ClawWorkspace::init(&belt_home)?;
+                    tracing::info!(path = %claw_ws.path.display(), "claw workspace initialized");
+
+                    if result.created {
+                        println!(
+                            "Workspace '{}' registered successfully.",
+                            result.workspace_name
+                        );
+                    } else {
+                        println!(
+                            "Workspace '{}' updated successfully.",
+                            result.workspace_name
+                        );
+                    }
+                    println!("  Config: {}", result.config_path);
+                    println!("  Sources: {}", result.source_count);
+                    println!("  Cron jobs seeded: {}", result.cron_jobs_seeded);
+                }
+                WorkspaceCommands::List => {
+                    let workspaces = db.list_workspaces()?;
+                    if workspaces.is_empty() {
+                        println!("No workspaces registered.");
+                    } else {
+                        println!("{:<20} {:<50} CREATED", "NAME", "CONFIG");
+                        for (name, config_path, created_at) in &workspaces {
+                            println!("{:<20} {:<50} {}", name, config_path, created_at);
+                        }
+                    }
+                }
+                WorkspaceCommands::Show { name } => {
+                    let (ws_name, config_path, created_at) = db.get_workspace(&name)?;
+                    println!("Name:       {ws_name}");
+                    println!("Config:     {config_path}");
+                    println!("Created at: {created_at}");
+
+                    // Show associated cron jobs
+                    let jobs = db.list_cron_jobs()?;
+                    let ws_jobs: Vec<_> = jobs
+                        .iter()
+                        .filter(|j| j.workspace.as_deref() == Some(&name))
+                        .collect();
+                    if !ws_jobs.is_empty() {
+                        println!("\nCron jobs:");
+                        for job in &ws_jobs {
+                            let status = if job.enabled { "enabled" } else { "disabled" };
+                            println!("  {} [{}] ({})", job.name, job.schedule, status);
+                        }
+                    }
+                }
             }
-            WorkspaceCommands::List => {
-                tracing::info!("listing workspaces...");
-            }
-            WorkspaceCommands::Show { name } => {
-                tracing::info!(name, "showing workspace...");
-            }
-        },
+        }
         Commands::Queue { command } => match command {
             QueueCommands::List { phase, workspace } => {
                 tracing::info!(?phase, ?workspace, "listing queue items...");

--- a/crates/belt-infra/src/db.rs
+++ b/crates/belt-infra/src/db.rs
@@ -683,20 +683,22 @@ impl Database {
             .map_err(|e| BeltError::Database(e.to_string()))?;
 
         rows.into_iter()
-            .map(|(wid, ws, rt, model, input, output, cache_read, cache_write, dur, created)| {
-                Ok(TokenUsageRow {
-                    work_id: wid,
-                    workspace: ws,
-                    runtime: rt,
-                    model,
-                    input_tokens: input as u64,
-                    output_tokens: output as u64,
-                    cache_read_tokens: cache_read.map(|v| v as u64),
-                    cache_write_tokens: cache_write.map(|v| v as u64),
-                    duration_ms: dur.map(|d| d as u64),
-                    created_at: parse_datetime(&created)?,
-                })
-            })
+            .map(
+                |(wid, ws, rt, model, input, output, cache_read, cache_write, dur, created)| {
+                    Ok(TokenUsageRow {
+                        work_id: wid,
+                        workspace: ws,
+                        runtime: rt,
+                        model,
+                        input_tokens: input as u64,
+                        output_tokens: output as u64,
+                        cache_read_tokens: cache_read.map(|v| v as u64),
+                        cache_write_tokens: cache_write.map(|v| v as u64),
+                        duration_ms: dur.map(|d| d as u64),
+                        created_at: parse_datetime(&created)?,
+                    })
+                },
+            )
             .collect()
     }
 
@@ -739,20 +741,22 @@ impl Database {
             .map_err(|e| BeltError::Database(e.to_string()))?;
 
         rows.into_iter()
-            .map(|(wid, ws, rt, model, input, output, cache_read, cache_write, dur, created)| {
-                Ok(TokenUsageRow {
-                    work_id: wid,
-                    workspace: ws,
-                    runtime: rt,
-                    model,
-                    input_tokens: input as u64,
-                    output_tokens: output as u64,
-                    cache_read_tokens: cache_read.map(|v| v as u64),
-                    cache_write_tokens: cache_write.map(|v| v as u64),
-                    duration_ms: dur.map(|d| d as u64),
-                    created_at: parse_datetime(&created)?,
-                })
-            })
+            .map(
+                |(wid, ws, rt, model, input, output, cache_read, cache_write, dur, created)| {
+                    Ok(TokenUsageRow {
+                        work_id: wid,
+                        workspace: ws,
+                        runtime: rt,
+                        model,
+                        input_tokens: input as u64,
+                        output_tokens: output as u64,
+                        cache_read_tokens: cache_read.map(|v| v as u64),
+                        cache_write_tokens: cache_write.map(|v| v as u64),
+                        duration_ms: dur.map(|d| d as u64),
+                        created_at: parse_datetime(&created)?,
+                    })
+                },
+            )
             .collect()
     }
 }

--- a/crates/belt-infra/src/lib.rs
+++ b/crates/belt-infra/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod db;
+pub mod onboarding;
 pub mod runtimes;
 pub mod sources;
+pub mod workspace_loader;
 pub mod worktree;

--- a/crates/belt-infra/src/onboarding.rs
+++ b/crates/belt-infra/src/onboarding.rs
@@ -1,0 +1,226 @@
+//! Workspace onboarding flow.
+//!
+//! Orchestrates the full workspace registration process:
+//! 1. Parse workspace.yml
+//! 2. Save workspace to DB
+//! 3. Seed per-workspace cron jobs (CR-13)
+
+use std::path::Path;
+
+use belt_core::workspace::WorkspaceConfig;
+
+use crate::db::Database;
+use crate::workspace_loader;
+
+/// Result of a successful onboarding operation.
+#[derive(Debug)]
+pub struct OnboardingResult {
+    /// The parsed workspace name.
+    pub workspace_name: String,
+    /// Absolute path to the config file that was registered.
+    pub config_path: String,
+    /// Number of data sources configured.
+    pub source_count: usize,
+    /// Number of cron jobs seeded.
+    pub cron_jobs_seeded: usize,
+    /// Whether the workspace was newly created (vs. updated).
+    pub created: bool,
+}
+
+/// Per-workspace cron seed definitions (CR-13).
+///
+/// Each tuple is `(job_name_suffix, schedule_expression)`.
+const WORKSPACE_CRON_SEEDS: &[(&str, &str)] = &[
+    ("hitl_timeout", "*/5 * * * *"),
+    ("daily_report", "0 6 * * *"),
+    ("log_cleanup", "0 0 * * *"),
+    ("evaluate", "*/1 * * * *"),
+];
+
+/// Execute the full onboarding flow for a workspace.
+///
+/// Steps:
+/// 1. Load and validate the workspace config from `config_path`.
+/// 2. Register (or update) the workspace in the database.
+/// 3. Seed per-workspace cron jobs.
+///
+/// # Errors
+/// Returns an error if the config file cannot be read/parsed, or if DB
+/// operations fail.
+pub fn onboard_workspace(db: &Database, config_path: &Path) -> anyhow::Result<OnboardingResult> {
+    // Step 1: Parse workspace.yml
+    let config: WorkspaceConfig = workspace_loader::load_workspace_config(config_path)?;
+
+    let abs_path = std::fs::canonicalize(config_path)
+        .unwrap_or_else(|_| config_path.to_path_buf())
+        .to_string_lossy()
+        .to_string();
+
+    // Step 2: Save workspace to DB (insert or update)
+    let created = match db.get_workspace(&config.name) {
+        Ok(_) => {
+            db.update_workspace(&config.name, &abs_path)?;
+            tracing::info!(name = %config.name, "workspace updated");
+            false
+        }
+        Err(belt_core::error::BeltError::WorkspaceNotFound(_)) => {
+            db.add_workspace(&config.name, &abs_path)?;
+            tracing::info!(name = %config.name, "workspace registered");
+            true
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    // Step 3: Seed per-workspace cron jobs (CR-13)
+    let cron_jobs_seeded = seed_workspace_cron_jobs(db, &config.name)?;
+
+    Ok(OnboardingResult {
+        workspace_name: config.name,
+        config_path: abs_path,
+        source_count: config.sources.len(),
+        cron_jobs_seeded,
+        created,
+    })
+}
+
+/// Seed built-in cron jobs scoped to a workspace.
+///
+/// Job names are prefixed with the workspace name to avoid collisions
+/// (e.g. `my-project:hitl_timeout`). Existing jobs are skipped.
+fn seed_workspace_cron_jobs(db: &Database, workspace_name: &str) -> anyhow::Result<usize> {
+    let mut seeded = 0;
+
+    for (suffix, schedule) in WORKSPACE_CRON_SEEDS {
+        let job_name = format!("{workspace_name}:{suffix}");
+
+        // Check if job already exists by listing and filtering.
+        // This is acceptable because the number of cron jobs is small.
+        let existing = db.list_cron_jobs()?;
+        let already_exists = existing.iter().any(|j| j.name == job_name);
+
+        if already_exists {
+            tracing::debug!(job = %job_name, "cron job already exists, skipping");
+            continue;
+        }
+
+        db.add_cron_job(&job_name, schedule, Some(workspace_name))?;
+        tracing::info!(job = %job_name, schedule, "cron job seeded");
+        seeded += 1;
+    }
+
+    Ok(seeded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn test_db() -> Database {
+        Database::open_in_memory().expect("in-memory DB should open")
+    }
+
+    fn write_workspace_yaml(content: &str) -> tempfile::NamedTempFile {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(content.as_bytes()).unwrap();
+        tmp
+    }
+
+    const VALID_YAML: &str = r#"
+name: test-project
+concurrency: 2
+sources:
+  github:
+    url: https://github.com/org/repo
+    scan_interval_secs: 300
+  slack:
+    url: https://slack.com/workspace
+"#;
+
+    #[test]
+    fn onboard_creates_workspace_and_cron_jobs() {
+        let db = test_db();
+        let tmp = write_workspace_yaml(VALID_YAML);
+
+        let result = onboard_workspace(&db, tmp.path()).unwrap();
+        assert_eq!(result.workspace_name, "test-project");
+        assert_eq!(result.source_count, 2);
+        assert_eq!(result.cron_jobs_seeded, 4);
+        assert!(result.created);
+
+        // Verify workspace is in DB
+        let (name, _config_path, _created_at) = db.get_workspace("test-project").unwrap();
+        assert_eq!(name, "test-project");
+
+        // Verify cron jobs are in DB
+        let jobs = db.list_cron_jobs().unwrap();
+        assert_eq!(jobs.len(), 4);
+        let job_names: Vec<&str> = jobs.iter().map(|j| j.name.as_str()).collect();
+        assert!(job_names.contains(&"test-project:hitl_timeout"));
+        assert!(job_names.contains(&"test-project:daily_report"));
+        assert!(job_names.contains(&"test-project:log_cleanup"));
+        assert!(job_names.contains(&"test-project:evaluate"));
+
+        // All jobs should be scoped to the workspace
+        for job in &jobs {
+            assert_eq!(job.workspace.as_deref(), Some("test-project"));
+            assert!(job.enabled);
+        }
+    }
+
+    #[test]
+    fn onboard_updates_existing_workspace() {
+        let db = test_db();
+        let tmp = write_workspace_yaml(VALID_YAML);
+
+        // First onboard
+        let result1 = onboard_workspace(&db, tmp.path()).unwrap();
+        assert!(result1.created);
+        assert_eq!(result1.cron_jobs_seeded, 4);
+
+        // Second onboard should update, not create
+        let result2 = onboard_workspace(&db, tmp.path()).unwrap();
+        assert!(!result2.created);
+        assert_eq!(result2.cron_jobs_seeded, 0); // Already exist
+
+        // Still only 4 cron jobs total
+        let jobs = db.list_cron_jobs().unwrap();
+        assert_eq!(jobs.len(), 4);
+    }
+
+    #[test]
+    fn onboard_invalid_config_errors() {
+        let db = test_db();
+        let result = onboard_workspace(&db, Path::new("/nonexistent/workspace.yml"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn cron_seed_names_are_workspace_scoped() {
+        let db = test_db();
+        let yaml_a = r#"
+name: project-a
+sources:
+  github:
+    url: https://github.com/org/repo-a
+"#;
+        let yaml_b = r#"
+name: project-b
+sources:
+  github:
+    url: https://github.com/org/repo-b
+"#;
+        let tmp_a = write_workspace_yaml(yaml_a);
+        let tmp_b = write_workspace_yaml(yaml_b);
+
+        onboard_workspace(&db, tmp_a.path()).unwrap();
+        onboard_workspace(&db, tmp_b.path()).unwrap();
+
+        let jobs = db.list_cron_jobs().unwrap();
+        assert_eq!(jobs.len(), 8); // 4 per workspace
+
+        let job_names: Vec<&str> = jobs.iter().map(|j| j.name.as_str()).collect();
+        assert!(job_names.contains(&"project-a:hitl_timeout"));
+        assert!(job_names.contains(&"project-b:hitl_timeout"));
+    }
+}

--- a/crates/belt-infra/src/workspace_loader.rs
+++ b/crates/belt-infra/src/workspace_loader.rs
@@ -1,0 +1,59 @@
+//! Load and parse workspace configuration from a YAML file.
+
+use std::path::Path;
+
+use belt_core::workspace::WorkspaceConfig;
+
+/// Load a [`WorkspaceConfig`] from the given YAML file path.
+///
+/// # Errors
+/// Returns an error if the file cannot be read or parsed.
+pub fn load_workspace_config(path: &Path) -> anyhow::Result<WorkspaceConfig> {
+    let content = std::fs::read_to_string(path).map_err(|e| {
+        anyhow::anyhow!("failed to read workspace config '{}': {e}", path.display())
+    })?;
+    let config: WorkspaceConfig = serde_yaml::from_str(&content).map_err(|e| {
+        anyhow::anyhow!("failed to parse workspace config '{}': {e}", path.display())
+    })?;
+    Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn load_valid_workspace_config() {
+        let yaml = r#"
+name: test-project
+concurrency: 2
+sources:
+  github:
+    url: https://github.com/org/repo
+    scan_interval_secs: 300
+"#;
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(yaml.as_bytes()).unwrap();
+
+        let config = load_workspace_config(tmp.path()).unwrap();
+        assert_eq!(config.name, "test-project");
+        assert_eq!(config.concurrency, 2);
+        assert!(config.sources.contains_key("github"));
+    }
+
+    #[test]
+    fn load_missing_file_errors() {
+        let result = load_workspace_config(Path::new("/nonexistent/workspace.yml"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn load_invalid_yaml_errors() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"not: [valid: yaml: {{").unwrap();
+
+        let result = load_workspace_config(tmp.path());
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
Closes #62

## Summary
- Add workspace_loader.rs for workspace.yml parsing
- Add onboarding.rs for full onboarding orchestration (DB save + cron seed)
- Wire `belt workspace add/list/show` CLI handlers
- Seed per-workspace cron jobs (hitl_timeout, daily_report, log_cleanup, evaluate)
- Auto-trigger claw init on workspace add

## Test plan
- [ ] cargo check -p belt-infra -p belt-cli
- [ ] cargo test -p belt-infra (workspace_loader + onboarding tests)
- [ ] Manual: belt workspace add --config workspace.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)