### PR TITLE
feat(github): implement PR feedback loop and review event processing

### DIFF
--- a/crates/belt-core/src/context.rs
+++ b/crates/belt-core/src/context.rs
@@ -104,23 +104,32 @@ pub struct IssueContext {
     pub author: String,
 }
 
+/// PR context including review information, branch details, and labels.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PrContext {
     pub number: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub head_branch: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<String>,
+    pub body: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub author: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+    #[serde(default)]
+    pub draft: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merge_status: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub labels: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub reviews: Vec<ReviewContext>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub review_comments: Vec<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub commits: Vec<CommitContext>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub files: Vec<FileChangeContext>,
 }
 
 /// PR에 포함된 커밋 요약.
@@ -139,6 +148,24 @@ pub struct FileChangeContext {
     pub additions: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deletions: Option<u64>,
+}
+
+/// Individual review on a PR.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewContext {
+    pub reviewer: String,
+    pub state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub submitted_at: Option<String>,
+}
+
+impl PrContext {
+    /// Returns `true` if any review has `CHANGES_REQUESTED` state.
+    pub fn has_changes_requested(&self) -> bool {
+        self.reviews.iter().any(|r| r.state == "CHANGES_REQUESTED")
+    }
 }
 
 impl ItemContext {
@@ -270,5 +297,91 @@ mod tests {
         let json = serde_json::to_string(&source).unwrap();
         assert!(json.contains("\"type\":\"github\""));
         assert!(!json.contains("source_type"));
+    }
+
+    #[test]
+    fn pr_context_has_changes_requested() {
+        let pr = PrContext {
+            number: 10,
+            title: Some("Fix bug".to_string()),
+            body: None,
+            author: Some("dev".to_string()),
+            state: Some("OPEN".to_string()),
+            draft: false,
+            head_branch: Some("fix/bug".to_string()),
+            base_branch: Some("main".to_string()),
+            merge_status: None,
+            labels: vec![],
+            reviews: vec![
+                ReviewContext {
+                    reviewer: "reviewer1".to_string(),
+                    state: "APPROVED".to_string(),
+                    body: None,
+                    submitted_at: None,
+                },
+                ReviewContext {
+                    reviewer: "reviewer2".to_string(),
+                    state: "CHANGES_REQUESTED".to_string(),
+                    body: Some("Please fix the tests".to_string()),
+                    submitted_at: Some("2026-03-24T10:00:00Z".to_string()),
+                },
+            ],
+            review_comments: vec![],
+        };
+        assert!(pr.has_changes_requested());
+    }
+
+    #[test]
+    fn pr_context_no_changes_requested() {
+        let pr = PrContext {
+            number: 10,
+            title: None,
+            body: None,
+            author: None,
+            state: None,
+            draft: false,
+            head_branch: None,
+            base_branch: None,
+            merge_status: None,
+            labels: vec![],
+            reviews: vec![ReviewContext {
+                reviewer: "reviewer1".to_string(),
+                state: "APPROVED".to_string(),
+                body: None,
+                submitted_at: None,
+            }],
+            review_comments: vec![],
+        };
+        assert!(!pr.has_changes_requested());
+    }
+
+    #[test]
+    fn pr_context_json_roundtrip() {
+        let pr = PrContext {
+            number: 5,
+            title: Some("Add feature".to_string()),
+            body: Some("Description".to_string()),
+            author: Some("dev".to_string()),
+            state: Some("OPEN".to_string()),
+            draft: true,
+            head_branch: Some("feat/new".to_string()),
+            base_branch: Some("main".to_string()),
+            merge_status: Some("MERGEABLE".to_string()),
+            labels: vec!["enhancement".to_string()],
+            reviews: vec![ReviewContext {
+                reviewer: "lead".to_string(),
+                state: "CHANGES_REQUESTED".to_string(),
+                body: Some("Needs tests".to_string()),
+                submitted_at: Some("2026-03-24T12:00:00Z".to_string()),
+            }],
+            review_comments: vec!["inline comment".to_string()],
+        };
+        let json = serde_json::to_string_pretty(&pr).unwrap();
+        let parsed: PrContext = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.number, 5);
+        assert!(parsed.draft);
+        assert_eq!(parsed.reviews.len(), 1);
+        assert_eq!(parsed.reviews[0].state, "CHANGES_REQUESTED");
+        assert!(parsed.has_changes_requested());
     }
 }

--- a/crates/belt-daemon/src/cron.rs
+++ b/crates/belt-daemon/src/cron.rs
@@ -418,6 +418,22 @@ impl CronHandler for EvaluateJob {
     }
 }
 
+/// Periodically scans open PRs for `changes_requested` reviews.
+///
+/// When a PR has a `CHANGES_REQUESTED` review, this job creates a new
+/// queue item so the feedback loop can process the review comments and
+/// push updated changes.
+pub struct PrReviewScanJob;
+
+impl CronHandler for PrReviewScanJob {
+    fn execute(&self, _ctx: &CronContext) -> Result<(), BeltError> {
+        // TODO: iterate workspaces, call GitHubDataSource::collect_review_items,
+        // enqueue new items for PRs with changes_requested reviews.
+        tracing::info!("PrReviewScanJob: scanning PRs for changes_requested reviews");
+        Ok(())
+    }
+}
+
 /// Create all built-in jobs with their default schedules.
 ///
 /// Requires shared dependencies (database, worktree manager, etc.)
@@ -467,6 +483,14 @@ pub fn builtin_jobs(deps: BuiltinJobDeps) -> Vec<CronJobDef> {
                 belt_home: deps.belt_home,
                 workspace: deps.workspace,
             }),
+        },
+        CronJobDef {
+            name: "pr_review_scan".to_string(),
+            schedule: CronSchedule::Interval(Duration::from_secs(5 * 60)),
+            workspace: None,
+            enabled: true,
+            last_run_at: None,
+            handler: Box::new(PrReviewScanJob),
         },
     ]
 }
@@ -751,13 +775,14 @@ mod tests {
     fn builtin_jobs_are_valid() {
         let deps = make_test_deps();
         let jobs = builtin_jobs(deps);
-        assert_eq!(jobs.len(), 4);
+        assert_eq!(jobs.len(), 5);
 
         let names: Vec<&str> = jobs.iter().map(|j| j.name.as_str()).collect();
         assert!(names.contains(&"hitl_timeout"));
         assert!(names.contains(&"daily_report"));
         assert!(names.contains(&"log_cleanup"));
         assert!(names.contains(&"evaluate"));
+        assert!(names.contains(&"pr_review_scan"));
     }
 
     // -- Built-in job logic tests --

--- a/crates/belt-daemon/src/daemon.rs
+++ b/crates/belt-daemon/src/daemon.rs
@@ -106,7 +106,7 @@ impl Daemon {
             config,
             sources,
             executor: Arc::new(ActionExecutor::new(registry)),
-            worktree_mgr: Arc::from(worktree_mgr),
+            worktree_mgr: worktree_mgr.into(),
             tracker: ConcurrencyTracker::new(max_concurrent),
             queue: VecDeque::new(),
             history: Vec::new(),

--- a/crates/belt-infra/src/sources/github.rs
+++ b/crates/belt-infra/src/sources/github.rs
@@ -2,8 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use belt_core::context::{
-    CommitContext, FileChangeContext, IssueContext, ItemContext, PrContext, QueueContext,
-    SourceContext,
+    IssueContext, ItemContext, PrContext, QueueContext, ReviewContext, SourceContext,
 };
 use belt_core::phase::QueuePhase;
 use belt_core::queue::QueueItem;
@@ -79,8 +78,7 @@ impl GitHubDataSource {
 
     /// `gh` CLI로 해당 이슈에 연결된 PR을 조회한다.
     ///
-    /// `gh pr list`에서 현재 이슈 번호와 연결된 PR을 찾고,
-    /// 리뷰 코멘트, 커밋 목록, 파일 변경사항을 함께 조회한다.
+    /// title, body, author, state, draft, branch, labels, merge status를 포함한다.
     async fn fetch_linked_pr(repo: &str, issue_number: i64) -> Option<PrContext> {
         let output = tokio::process::Command::new("gh")
             .args([
@@ -91,7 +89,7 @@ impl GitHubDataSource {
                 "--search",
                 &format!("linked:issue:{issue_number}"),
                 "--json",
-                "number,title,state,url,headRefName",
+                "number,title,body,author,state,isDraft,headRefName,baseRefName,labels,mergeable",
                 "--limit",
                 "1",
             ])
@@ -104,143 +102,159 @@ impl GitHubDataSource {
         let pr = prs.first()?;
 
         let number = pr["number"].as_i64()?;
-        let head_branch = pr["headRefName"].as_str().map(|s| s.to_string());
         let title = pr["title"].as_str().map(|s| s.to_string());
+        let body = pr["body"].as_str().map(|s| s.to_string());
+        let author = pr["author"]["login"].as_str().map(|s| s.to_string());
         let state = pr["state"].as_str().map(|s| s.to_string());
-        let url = pr["url"].as_str().map(|s| s.to_string());
+        let draft = pr["isDraft"].as_bool().unwrap_or(false);
+        let head_branch = pr["headRefName"].as_str().map(|s| s.to_string());
+        let base_branch = pr["baseRefName"].as_str().map(|s| s.to_string());
+        let merge_status = pr["mergeable"].as_str().map(|s| s.to_string());
+        let labels = pr["labels"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|l| l["name"].as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
 
-        // 리뷰 코멘트, 커밋, 파일 변경사항을 병렬로 조회
-        let (reviews, commits, files) = tokio::join!(
-            Self::fetch_pr_reviews(repo, number),
-            Self::fetch_pr_commits(repo, number),
-            Self::fetch_pr_files(repo, number),
-        );
+        // Fetch reviews for this PR
+        let reviews = Self::fetch_pr_reviews(repo, number)
+            .await
+            .unwrap_or_default();
 
         Some(PrContext {
             number,
-            head_branch,
             title,
+            body,
+            author,
             state,
-            url,
-            review_comments: reviews.unwrap_or_default(),
-            commits: commits.unwrap_or_default(),
-            files: files.unwrap_or_default(),
+            draft,
+            head_branch,
+            base_branch,
+            merge_status,
+            labels,
+            reviews,
+            review_comments: vec![],
         })
     }
 
-    /// `gh` CLI로 PR의 리뷰 코멘트를 조회한다.
-    async fn fetch_pr_reviews(repo: &str, pr_number: i64) -> Option<Vec<String>> {
+    /// `gh` CLI로 PR의 리뷰 목록을 조회한다.
+    async fn fetch_pr_reviews(repo: &str, pr_number: i64) -> Option<Vec<ReviewContext>> {
         let output = tokio::process::Command::new("gh")
             .args([
-                "pr",
-                "view",
-                &pr_number.to_string(),
-                "--repo",
-                repo,
-                "--json",
-                "reviews",
+                "api",
+                &format!("repos/{repo}/pulls/{pr_number}/reviews"),
+                "--jq",
+                ".[] | {user: .user.login, state: .state, body: .body, submitted_at: .submitted_at}",
             ])
             .output()
             .await;
 
         let output = output.ok().filter(|o| o.status.success())?;
         let stdout = String::from_utf8_lossy(&output.stdout);
-        let val: serde_json::Value = serde_json::from_str(&stdout).ok()?;
 
-        let reviews = val["reviews"].as_array()?;
-        let comments: Vec<String> = reviews
-            .iter()
-            .filter_map(|r| r["body"].as_str())
-            .filter(|body| !body.is_empty())
-            .map(|s| s.to_string())
-            .collect();
-
-        Some(comments)
+        let mut reviews = Vec::new();
+        for line in stdout.lines() {
+            if let Ok(val) = serde_json::from_str::<serde_json::Value>(line) {
+                let reviewer = val["user"].as_str().unwrap_or("").to_string();
+                let state = val["state"].as_str().unwrap_or("").to_string();
+                let body = val["body"].as_str().and_then(|s| {
+                    if s.is_empty() {
+                        None
+                    } else {
+                        Some(s.to_string())
+                    }
+                });
+                let submitted_at = val["submitted_at"].as_str().map(|s| s.to_string());
+                reviews.push(ReviewContext {
+                    reviewer,
+                    state,
+                    body,
+                    submitted_at,
+                });
+            }
+        }
+        Some(reviews)
     }
 
-    /// `gh` CLI로 PR의 커밋 목록을 조회한다.
-    async fn fetch_pr_commits(repo: &str, pr_number: i64) -> Option<Vec<CommitContext>> {
+    /// PR에 `changes_requested` 리뷰가 있는지 확인하고,
+    /// 해당하는 경우 새 큐 아이템을 생성한다.
+    ///
+    /// `review_scan_state`는 changes_requested 감지 시 생성할 워크플로우 상태 이름이다.
+    pub async fn collect_review_items(
+        &self,
+        workspace: &WorkspaceConfig,
+        review_scan_state: &str,
+    ) -> Result<Vec<QueueItem>> {
+        let github_config = match workspace.sources.get("github") {
+            Some(config) => config,
+            None => return Ok(Vec::new()),
+        };
+
+        let repo_name = Self::extract_repo_name(&github_config.url)
+            .unwrap_or_else(|| "unknown/repo".to_string());
+
+        // List open PRs
         let output = tokio::process::Command::new("gh")
             .args([
                 "pr",
-                "view",
-                &pr_number.to_string(),
+                "list",
                 "--repo",
-                repo,
+                &repo_name,
+                "--state",
+                "open",
                 "--json",
-                "commits",
+                "number,title,headRefName",
+                "--limit",
+                "50",
             ])
             .output()
             .await;
 
-        let output = output.ok().filter(|o| o.status.success())?;
+        let output = match output {
+            Ok(o) if o.status.success() => o,
+            _ => return Ok(Vec::new()),
+        };
+
         let stdout = String::from_utf8_lossy(&output.stdout);
-        let val: serde_json::Value = serde_json::from_str(&stdout).ok()?;
+        let prs: Vec<serde_json::Value> = serde_json::from_str(&stdout).unwrap_or_default();
 
-        let commits = val["commits"].as_array()?;
-        let result: Vec<CommitContext> = commits
-            .iter()
-            .filter_map(|c| {
-                let sha = c["oid"].as_str().unwrap_or_default().to_string();
-                let message = c["messageHeadline"]
-                    .as_str()
-                    .unwrap_or_default()
-                    .to_string();
-                let author = c["authors"]
-                    .as_array()
-                    .and_then(|a| a.first())
-                    .and_then(|a| a["login"].as_str().or_else(|| a["name"].as_str()))
-                    .unwrap_or_default()
-                    .to_string();
-                if sha.is_empty() {
-                    return None;
-                }
-                Some(CommitContext {
-                    sha,
-                    message,
-                    author,
-                })
-            })
-            .collect();
+        let mut items = Vec::new();
+        for pr in prs {
+            let number = match pr["number"].as_i64() {
+                Some(n) => n,
+                None => continue,
+            };
+            let title = pr["title"].as_str().unwrap_or("").to_string();
 
-        Some(result)
-    }
+            // Check reviews for this PR
+            let reviews = Self::fetch_pr_reviews(&repo_name, number)
+                .await
+                .unwrap_or_default();
 
-    /// `gh` CLI로 PR의 파일 변경사항을 조회한다.
-    async fn fetch_pr_files(repo: &str, pr_number: i64) -> Option<Vec<FileChangeContext>> {
-        let output = tokio::process::Command::new("gh")
-            .args([
-                "pr",
-                "view",
-                &pr_number.to_string(),
-                "--repo",
-                repo,
-                "--json",
-                "files",
-            ])
-            .output()
-            .await;
+            let has_changes_requested = reviews.iter().any(|r| r.state == "CHANGES_REQUESTED");
+            if !has_changes_requested {
+                continue;
+            }
 
-        let output = output.ok().filter(|o| o.status.success())?;
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let val: serde_json::Value = serde_json::from_str(&stdout).ok()?;
+            let source_id = format!("github:{repo_name}!{number}");
+            let work_id = QueueItem::make_work_id(&source_id, review_scan_state);
 
-        let files = val["files"].as_array()?;
-        let result: Vec<FileChangeContext> = files
-            .iter()
-            .filter_map(|f| {
-                let path = f["path"].as_str()?.to_string();
-                let additions = f["additions"].as_u64();
-                let deletions = f["deletions"].as_u64();
-                Some(FileChangeContext {
-                    path,
-                    additions,
-                    deletions,
-                })
-            })
-            .collect();
+            items.push(QueueItem {
+                work_id,
+                source_id,
+                workspace_id: workspace.name.clone(),
+                state: review_scan_state.to_string(),
+                phase: QueuePhase::Pending,
+                title: Some(format!("[review] {title}")),
+                created_at: chrono::Utc::now().to_rfc3339(),
+                updated_at: chrono::Utc::now().to_rfc3339(),
+            });
+        }
 
-        Some(result)
+        Ok(items)
     }
 
     /// `gh repo view`로 기본 브랜치를 조회한다.


### PR DESCRIPTION
Closes #66

## Summary
- Extend PrContext with author, draft, base_branch, merge_status, labels, reviews
- Add ReviewContext type and has_changes_requested() detection
- Implement fetch_pr_reviews() via GitHub API
- Add collect_review_items() for creating queue items from changes_requested
- Register PrReviewScanJob as builtin cron (5min interval)

## Test plan
- [ ] cargo test -p belt-core -p belt-infra -p belt-daemon

Generated with Claude Code