### PR TITLE
feat(spec): implement spec lifecycle with state machine and CLI

### DIFF
--- a/crates/belt-cli/Cargo.toml
+++ b/crates/belt-cli/Cargo.toml
@@ -19,6 +19,7 @@ anyhow = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+chrono = { workspace = true }
 dirs = "6"
 
 [dev-dependencies]

--- a/crates/belt-cli/src/main.rs
+++ b/crates/belt-cli/src/main.rs
@@ -52,6 +52,11 @@ enum Commands {
         #[arg(short, long)]
         prompt: Option<String>,
     },
+    /// Spec lifecycle management.
+    Spec {
+        #[command(subcommand)]
+        command: SpecCommands,
+    },
     /// Claw interactive management session.
     Claw {
         #[command(subcommand)]
@@ -118,6 +123,91 @@ enum QueueCommands {
     Skip { work_id: String },
 }
 
+#[derive(Subcommand)]
+enum SpecCommands {
+    /// Add a new spec.
+    Add {
+        /// Workspace ID.
+        #[arg(long)]
+        workspace: String,
+        /// Spec name.
+        #[arg(long)]
+        name: String,
+        /// Spec content / description.
+        #[arg(long)]
+        content: String,
+        /// Optional priority (lower is higher).
+        #[arg(long)]
+        priority: Option<i32>,
+        /// Optional comma-separated labels.
+        #[arg(long)]
+        labels: Option<String>,
+        /// Optional comma-separated spec IDs this depends on.
+        #[arg(long)]
+        depends_on: Option<String>,
+    },
+    /// List specs.
+    List {
+        /// Filter by workspace.
+        #[arg(long)]
+        workspace: Option<String>,
+        /// Filter by status.
+        #[arg(long)]
+        status: Option<String>,
+        /// Output as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show spec details.
+    Show {
+        /// Spec ID.
+        id: String,
+        /// Output as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Update spec fields.
+    Update {
+        /// Spec ID.
+        id: String,
+        /// New name.
+        #[arg(long)]
+        name: Option<String>,
+        /// New content.
+        #[arg(long)]
+        content: Option<String>,
+        /// New priority.
+        #[arg(long)]
+        priority: Option<i32>,
+        /// New labels.
+        #[arg(long)]
+        labels: Option<String>,
+        /// New depends_on.
+        #[arg(long)]
+        depends_on: Option<String>,
+    },
+    /// Pause an active spec.
+    Pause {
+        /// Spec ID.
+        id: String,
+    },
+    /// Resume a paused spec.
+    Resume {
+        /// Spec ID.
+        id: String,
+    },
+    /// Complete an active spec.
+    Complete {
+        /// Spec ID.
+        id: String,
+    },
+    /// Remove a spec.
+    Remove {
+        /// Spec ID.
+        id: String,
+    },
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
@@ -181,6 +271,167 @@ async fn main() -> anyhow::Result<()> {
                 tracing::info!(p, "executing prompt...");
             }
             // TODO: AgentRuntime implementation
+        }
+        Commands::Spec { command } => {
+            let belt_home = dirs::home_dir()
+                .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?
+                .join(".belt");
+            let db_path = belt_home.join("belt.db");
+            let db = belt_infra::db::Database::open(
+                db_path
+                    .to_str()
+                    .ok_or_else(|| anyhow::anyhow!("invalid db path"))?,
+            )?;
+
+            match command {
+                SpecCommands::Add {
+                    workspace,
+                    name,
+                    content,
+                    priority,
+                    labels,
+                    depends_on,
+                } => {
+                    let id = format!("spec-{}", chrono::Utc::now().timestamp_millis());
+                    let mut spec = belt_core::spec::Spec::new(id.clone(), workspace, name, content);
+                    spec.priority = priority;
+                    spec.labels = labels;
+                    spec.depends_on = depends_on;
+                    db.insert_spec(&spec)?;
+                    println!("spec created: {id}");
+                }
+                SpecCommands::List {
+                    workspace,
+                    status,
+                    json,
+                } => {
+                    let status_filter = status
+                        .map(|s| {
+                            s.parse::<belt_core::spec::SpecStatus>()
+                                .map_err(|e| anyhow::anyhow!(e))
+                        })
+                        .transpose()?;
+                    let specs = db.list_specs(workspace.as_deref(), status_filter)?;
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&specs)?);
+                    } else {
+                        if specs.is_empty() {
+                            println!("no specs found");
+                        } else {
+                            for spec in &specs {
+                                println!(
+                                    "{}\t{}\t{}\t{}",
+                                    spec.id, spec.name, spec.status, spec.workspace_id
+                                );
+                            }
+                        }
+                    }
+                }
+                SpecCommands::Show { id, json } => {
+                    let spec = db.get_spec(&id)?;
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&spec)?);
+                    } else {
+                        println!("ID:          {}", spec.id);
+                        println!("Name:        {}", spec.name);
+                        println!("Status:      {}", spec.status);
+                        println!("Workspace:   {}", spec.workspace_id);
+                        println!("Content:     {}", spec.content);
+                        if let Some(p) = spec.priority {
+                            println!("Priority:    {p}");
+                        }
+                        if let Some(l) = &spec.labels {
+                            println!("Labels:      {l}");
+                        }
+                        if let Some(d) = &spec.depends_on {
+                            println!("Depends On:  {d}");
+                        }
+                        println!("Created At:  {}", spec.created_at);
+                        println!("Updated At:  {}", spec.updated_at);
+                    }
+                }
+                SpecCommands::Update {
+                    id,
+                    name,
+                    content,
+                    priority,
+                    labels,
+                    depends_on,
+                } => {
+                    let mut spec = db.get_spec(&id)?;
+                    if let Some(n) = name {
+                        spec.name = n;
+                    }
+                    if let Some(c) = content {
+                        spec.content = c;
+                    }
+                    if priority.is_some() {
+                        spec.priority = priority;
+                    }
+                    if labels.is_some() {
+                        spec.labels = labels;
+                    }
+                    if depends_on.is_some() {
+                        spec.depends_on = depends_on;
+                    }
+                    db.update_spec(&spec)?;
+                    println!("spec updated: {id}");
+                }
+                SpecCommands::Pause { id } => {
+                    let spec = db.get_spec(&id)?;
+                    if !spec
+                        .status
+                        .can_transition_to(&belt_core::spec::SpecStatus::Paused)
+                    {
+                        anyhow::bail!(
+                            "cannot pause spec in status '{}': only active specs can be paused",
+                            spec.status
+                        );
+                    }
+                    db.update_spec_status(&id, belt_core::spec::SpecStatus::Paused)?;
+                    println!("spec paused: {id}");
+                }
+                SpecCommands::Resume { id } => {
+                    let spec = db.get_spec(&id)?;
+                    if !spec
+                        .status
+                        .can_transition_to(&belt_core::spec::SpecStatus::Active)
+                    {
+                        anyhow::bail!(
+                            "cannot resume spec in status '{}': only draft or paused specs can be activated",
+                            spec.status
+                        );
+                    }
+                    let was_draft = spec.status == belt_core::spec::SpecStatus::Draft;
+                    db.update_spec_status(&id, belt_core::spec::SpecStatus::Active)?;
+                    println!("spec activated: {id}");
+                    if was_draft {
+                        // TODO: trigger GitHub issue creation when spec transitions Draft -> Active
+                        tracing::info!(
+                            id,
+                            "spec activated from draft — GitHub issue creation pending"
+                        );
+                    }
+                }
+                SpecCommands::Complete { id } => {
+                    let spec = db.get_spec(&id)?;
+                    if !spec
+                        .status
+                        .can_transition_to(&belt_core::spec::SpecStatus::Completed)
+                    {
+                        anyhow::bail!(
+                            "cannot complete spec in status '{}': only active specs can be completed",
+                            spec.status
+                        );
+                    }
+                    db.update_spec_status(&id, belt_core::spec::SpecStatus::Completed)?;
+                    println!("spec completed: {id}");
+                }
+                SpecCommands::Remove { id } => {
+                    db.remove_spec(&id)?;
+                    println!("spec removed: {id}");
+                }
+            }
         }
         Commands::Claw { command } => match command {
             ClawCommands::Init { force } => {

--- a/crates/belt-core/src/error.rs
+++ b/crates/belt-core/src/error.rs
@@ -24,4 +24,10 @@ pub enum BeltError {
 
     #[error("worktree error: {0}")]
     Worktree(String),
+
+    #[error("spec not found: {0}")]
+    SpecNotFound(String),
+
+    #[error("invalid spec transition: {from} -> {to}")]
+    InvalidSpecTransition { from: String, to: String },
 }

--- a/crates/belt-core/src/lib.rs
+++ b/crates/belt-core/src/lib.rs
@@ -6,5 +6,6 @@ pub mod phase;
 pub mod queue;
 pub mod runtime;
 pub mod source;
+pub mod spec;
 pub mod state_machine;
 pub mod workspace;

--- a/crates/belt-core/src/spec.rs
+++ b/crates/belt-core/src/spec.rs
@@ -1,0 +1,306 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Spec lifecycle status.
+///
+/// ```text
+/// Draft -> Active -> [Paused <-> Active] -> Completed
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SpecStatus {
+    Draft,
+    Active,
+    Paused,
+    Completed,
+}
+
+impl SpecStatus {
+    /// Returns the string representation of this status.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SpecStatus::Draft => "draft",
+            SpecStatus::Active => "active",
+            SpecStatus::Paused => "paused",
+            SpecStatus::Completed => "completed",
+        }
+    }
+
+    /// Returns `true` if the status is terminal (no further transitions).
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, SpecStatus::Completed)
+    }
+
+    /// Returns `true` if transitioning from `self` to `to` is valid.
+    pub fn can_transition_to(&self, to: &SpecStatus) -> bool {
+        is_valid_spec_transition(*self, *to)
+    }
+}
+
+impl std::str::FromStr for SpecStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "draft" => Ok(SpecStatus::Draft),
+            "active" => Ok(SpecStatus::Active),
+            "paused" => Ok(SpecStatus::Paused),
+            "completed" => Ok(SpecStatus::Completed),
+            _ => Err(format!("invalid spec status: {s}")),
+        }
+    }
+}
+
+impl fmt::Display for SpecStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Validate a spec status transition.
+///
+/// Valid transitions:
+/// - Draft -> Active
+/// - Active -> Paused
+/// - Active -> Completed
+/// - Paused -> Active
+pub fn is_valid_spec_transition(from: SpecStatus, to: SpecStatus) -> bool {
+    use SpecStatus::*;
+    matches!(
+        (from, to),
+        (Draft, Active) | (Active, Paused) | (Active, Completed) | (Paused, Active)
+    )
+}
+
+/// Attempt a spec status transition, returning an error if invalid.
+pub fn transit_spec(from: SpecStatus, to: SpecStatus) -> Result<(), SpecTransitionError> {
+    if from == to {
+        return Err(SpecTransitionError::SameStatus(from));
+    }
+    if is_valid_spec_transition(from, to) {
+        Ok(())
+    } else {
+        Err(SpecTransitionError::Invalid { from, to })
+    }
+}
+
+/// Error type for invalid spec status transitions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpecTransitionError {
+    SameStatus(SpecStatus),
+    Invalid { from: SpecStatus, to: SpecStatus },
+}
+
+impl fmt::Display for SpecTransitionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SpecTransitionError::SameStatus(s) => {
+                write!(f, "cannot transit to same status: {s}")
+            }
+            SpecTransitionError::Invalid { from, to } => {
+                write!(f, "invalid spec transition: {from} -> {to}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SpecTransitionError {}
+
+/// A spec represents a planned unit of work with lifecycle management.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Spec {
+    /// Unique identifier.
+    pub id: String,
+    /// Associated workspace identifier.
+    pub workspace_id: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Current lifecycle status.
+    pub status: SpecStatus,
+    /// Spec content / description.
+    pub content: String,
+    /// Optional priority (lower is higher priority).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<i32>,
+    /// Optional comma-separated labels.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels: Option<String>,
+    /// Optional comma-separated IDs of specs this depends on.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub depends_on: Option<String>,
+    /// Creation timestamp (RFC 3339).
+    pub created_at: String,
+    /// Last update timestamp (RFC 3339).
+    pub updated_at: String,
+}
+
+impl Spec {
+    /// Create a new spec in Draft status.
+    pub fn new(id: String, workspace_id: String, name: String, content: String) -> Self {
+        let now = chrono::Utc::now().to_rfc3339();
+        Self {
+            id,
+            workspace_id,
+            name,
+            status: SpecStatus::Draft,
+            content,
+            priority: None,
+            labels: None,
+            depends_on: None,
+            created_at: now.clone(),
+            updated_at: now,
+        }
+    }
+
+    /// Attempt to transition this spec to a new status.
+    ///
+    /// Returns the previous status on success, or an error if the transition
+    /// is invalid.
+    pub fn transition_to(&mut self, to: SpecStatus) -> Result<SpecStatus, SpecTransitionError> {
+        transit_spec(self.status, to)?;
+        let previous = self.status;
+        self.status = to;
+        self.updated_at = chrono::Utc::now().to_rfc3339();
+        Ok(previous)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use SpecStatus::*;
+
+    #[test]
+    fn valid_transitions() {
+        assert!(transit_spec(Draft, Active).is_ok());
+        assert!(transit_spec(Active, Paused).is_ok());
+        assert!(transit_spec(Active, Completed).is_ok());
+        assert!(transit_spec(Paused, Active).is_ok());
+    }
+
+    #[test]
+    fn invalid_transitions() {
+        assert!(transit_spec(Draft, Paused).is_err());
+        assert!(transit_spec(Draft, Completed).is_err());
+        assert!(transit_spec(Paused, Completed).is_err());
+        assert!(transit_spec(Paused, Draft).is_err());
+        assert!(transit_spec(Completed, Active).is_err());
+        assert!(transit_spec(Completed, Draft).is_err());
+    }
+
+    #[test]
+    fn same_status_rejected() {
+        let statuses = [Draft, Active, Paused, Completed];
+        for s in statuses {
+            assert_eq!(
+                transit_spec(s, s).unwrap_err(),
+                SpecTransitionError::SameStatus(s)
+            );
+        }
+    }
+
+    #[test]
+    fn exhaustive_transition_count() {
+        let statuses = [Draft, Active, Paused, Completed];
+        let valid_count = statuses
+            .iter()
+            .flat_map(|&from| statuses.iter().map(move |&to| (from, to)))
+            .filter(|&(from, to)| is_valid_spec_transition(from, to))
+            .count();
+        assert_eq!(valid_count, 4);
+    }
+
+    #[test]
+    fn status_roundtrip() {
+        let statuses = [Draft, Active, Paused, Completed];
+        for s in statuses {
+            let str_val = s.to_string();
+            let parsed: SpecStatus = str_val.parse().unwrap();
+            assert_eq!(s, parsed);
+        }
+    }
+
+    #[test]
+    fn serde_json_roundtrip() {
+        let status = SpecStatus::Active;
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, "\"active\"");
+        let parsed: SpecStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, status);
+    }
+
+    #[test]
+    fn terminal_status() {
+        assert!(Completed.is_terminal());
+        assert!(!Draft.is_terminal());
+        assert!(!Active.is_terminal());
+        assert!(!Paused.is_terminal());
+    }
+
+    #[test]
+    fn new_spec_is_draft() {
+        let spec = Spec::new(
+            "spec-1".to_string(),
+            "ws-1".to_string(),
+            "My Spec".to_string(),
+            "Some content".to_string(),
+        );
+        assert_eq!(spec.status, Draft);
+    }
+
+    #[test]
+    fn spec_transition_method() {
+        let mut spec = Spec::new(
+            "spec-1".to_string(),
+            "ws-1".to_string(),
+            "My Spec".to_string(),
+            "content".to_string(),
+        );
+        let prev = spec.transition_to(Active).unwrap();
+        assert_eq!(prev, Draft);
+        assert_eq!(spec.status, Active);
+
+        let prev = spec.transition_to(Paused).unwrap();
+        assert_eq!(prev, Active);
+        assert_eq!(spec.status, Paused);
+
+        let prev = spec.transition_to(Active).unwrap();
+        assert_eq!(prev, Paused);
+
+        let prev = spec.transition_to(Completed).unwrap();
+        assert_eq!(prev, Active);
+        assert_eq!(spec.status, Completed);
+    }
+
+    #[test]
+    fn spec_transition_invalid() {
+        let mut spec = Spec::new(
+            "spec-1".to_string(),
+            "ws-1".to_string(),
+            "name".to_string(),
+            "content".to_string(),
+        );
+        assert!(spec.transition_to(Completed).is_err());
+    }
+
+    #[test]
+    fn spec_full_json_roundtrip() {
+        let mut spec = Spec::new(
+            "spec-1".to_string(),
+            "ws-1".to_string(),
+            "My Spec".to_string(),
+            "content here".to_string(),
+        );
+        spec.priority = Some(1);
+        spec.labels = Some("bug,urgent".to_string());
+        spec.depends_on = Some("spec-0".to_string());
+
+        let json = serde_json::to_string(&spec).unwrap();
+        let parsed: Spec = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.id, spec.id);
+        assert_eq!(parsed.priority, Some(1));
+        assert_eq!(parsed.labels.as_deref(), Some("bug,urgent"));
+        assert_eq!(parsed.depends_on.as_deref(), Some("spec-0"));
+    }
+}

--- a/crates/belt-infra/src/db.rs
+++ b/crates/belt-infra/src/db.rs
@@ -13,6 +13,7 @@ use belt_core::error::BeltError;
 use belt_core::phase::QueuePhase;
 use belt_core::queue::QueueItem;
 use belt_core::runtime::TokenUsage;
+use belt_core::spec::{Spec, SpecStatus};
 
 /// An immutable history event recording an attempt on a work item.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -171,6 +172,19 @@ impl Database {
                 cache_write_tokens INTEGER,
                 duration_ms        INTEGER,
                 created_at         TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS specs (
+                id           TEXT PRIMARY KEY,
+                workspace_id TEXT NOT NULL,
+                name         TEXT NOT NULL,
+                status       TEXT NOT NULL,
+                content      TEXT NOT NULL,
+                priority     INTEGER,
+                labels       TEXT,
+                depends_on   TEXT,
+                created_at   TEXT NOT NULL,
+                updated_at   TEXT NOT NULL
             );
             ",
         )
@@ -604,6 +618,174 @@ impl Database {
         Ok(())
     }
 
+    // ---- Specs -------------------------------------------------------------
+
+    /// Insert a new spec.
+    ///
+    /// # Errors
+    /// Returns `BeltError::Database` on constraint violation or I/O error.
+    pub fn insert_spec(&self, spec: &Spec) -> Result<(), BeltError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        conn.execute(
+            "INSERT INTO specs (id, workspace_id, name, status, content, priority, labels, depends_on, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            params![
+                spec.id,
+                spec.workspace_id,
+                spec.name,
+                spec.status.as_str(),
+                spec.content,
+                spec.priority,
+                spec.labels,
+                spec.depends_on,
+                spec.created_at,
+                spec.updated_at,
+            ],
+        )
+        .map_err(|e| BeltError::Database(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Retrieve a single spec by ID.
+    ///
+    /// # Errors
+    /// Returns `BeltError::SpecNotFound` if no row matches.
+    pub fn get_spec(&self, id: &str) -> Result<Spec, BeltError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        conn.query_row(
+            "SELECT id, workspace_id, name, status, content, priority, labels, depends_on, created_at, updated_at
+                 FROM specs WHERE id = ?1",
+            params![id],
+            |row| Ok(row_to_spec(row)),
+        )
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => BeltError::SpecNotFound(id.to_string()),
+            other => BeltError::Database(other.to_string()),
+        })?
+    }
+
+    /// List all specs, optionally filtered by workspace and/or status.
+    pub fn list_specs(
+        &self,
+        workspace: Option<&str>,
+        status: Option<SpecStatus>,
+    ) -> Result<Vec<Spec>, BeltError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        let mut sql = String::from(
+            "SELECT id, workspace_id, name, status, content, priority, labels, depends_on, created_at, updated_at FROM specs WHERE 1=1",
+        );
+        let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+
+        if let Some(ws) = workspace {
+            sql.push_str(" AND workspace_id = ?");
+            param_values.push(Box::new(ws.to_string()));
+        }
+        if let Some(s) = status {
+            sql.push_str(" AND status = ?");
+            param_values.push(Box::new(s.as_str().to_string()));
+        }
+
+        sql.push_str(" ORDER BY created_at ASC");
+
+        let params_ref: Vec<&dyn rusqlite::types::ToSql> =
+            param_values.iter().map(|p| p.as_ref()).collect();
+
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+
+        let specs = stmt
+            .query_map(params_ref.as_slice(), |row| Ok(row_to_spec(row)))
+            .map_err(|e| BeltError::Database(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+
+        specs.into_iter().collect::<Result<Vec<_>, _>>()
+    }
+
+    /// Update a spec's name, content, priority, labels, and depends_on.
+    ///
+    /// # Errors
+    /// Returns `BeltError::SpecNotFound` if no spec matches the given ID.
+    pub fn update_spec(&self, spec: &Spec) -> Result<(), BeltError> {
+        let now = Utc::now().to_rfc3339();
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        let rows = conn
+            .execute(
+                "UPDATE specs SET name = ?1, content = ?2, priority = ?3, labels = ?4, depends_on = ?5, updated_at = ?6 WHERE id = ?7",
+                params![
+                    spec.name,
+                    spec.content,
+                    spec.priority,
+                    spec.labels,
+                    spec.depends_on,
+                    now,
+                    spec.id,
+                ],
+            )
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        if rows == 0 {
+            return Err(BeltError::SpecNotFound(spec.id.clone()));
+        }
+        Ok(())
+    }
+
+    /// Update the status of a spec.
+    ///
+    /// This method does NOT validate state machine transitions; the caller
+    /// is responsible for checking `SpecStatus::can_transition_to` before
+    /// calling this.
+    ///
+    /// # Errors
+    /// Returns `BeltError::SpecNotFound` if no spec matches the given ID.
+    pub fn update_spec_status(&self, id: &str, status: SpecStatus) -> Result<(), BeltError> {
+        let now = Utc::now().to_rfc3339();
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        let rows = conn
+            .execute(
+                "UPDATE specs SET status = ?1, updated_at = ?2 WHERE id = ?3",
+                params![status.as_str(), now, id],
+            )
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        if rows == 0 {
+            return Err(BeltError::SpecNotFound(id.to_string()));
+        }
+        Ok(())
+    }
+
+    /// Remove a spec by ID.
+    ///
+    /// # Errors
+    /// Returns `BeltError::SpecNotFound` if no row was deleted.
+    pub fn remove_spec(&self, id: &str) -> Result<(), BeltError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        let rows = conn
+            .execute("DELETE FROM specs WHERE id = ?1", params![id])
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        if rows == 0 {
+            return Err(BeltError::SpecNotFound(id.to_string()));
+        }
+        Ok(())
+    }
+
     // ---- Token Usage -------------------------------------------------------
 
     /// Record token usage for a completed runtime invocation.
@@ -683,20 +865,22 @@ impl Database {
             .map_err(|e| BeltError::Database(e.to_string()))?;
 
         rows.into_iter()
-            .map(|(wid, ws, rt, model, input, output, cache_read, cache_write, dur, created)| {
-                Ok(TokenUsageRow {
-                    work_id: wid,
-                    workspace: ws,
-                    runtime: rt,
-                    model,
-                    input_tokens: input as u64,
-                    output_tokens: output as u64,
-                    cache_read_tokens: cache_read.map(|v| v as u64),
-                    cache_write_tokens: cache_write.map(|v| v as u64),
-                    duration_ms: dur.map(|d| d as u64),
-                    created_at: parse_datetime(&created)?,
-                })
-            })
+            .map(
+                |(wid, ws, rt, model, input, output, cache_read, cache_write, dur, created)| {
+                    Ok(TokenUsageRow {
+                        work_id: wid,
+                        workspace: ws,
+                        runtime: rt,
+                        model,
+                        input_tokens: input as u64,
+                        output_tokens: output as u64,
+                        cache_read_tokens: cache_read.map(|v| v as u64),
+                        cache_write_tokens: cache_write.map(|v| v as u64),
+                        duration_ms: dur.map(|d| d as u64),
+                        created_at: parse_datetime(&created)?,
+                    })
+                },
+            )
             .collect()
     }
 
@@ -739,20 +923,22 @@ impl Database {
             .map_err(|e| BeltError::Database(e.to_string()))?;
 
         rows.into_iter()
-            .map(|(wid, ws, rt, model, input, output, cache_read, cache_write, dur, created)| {
-                Ok(TokenUsageRow {
-                    work_id: wid,
-                    workspace: ws,
-                    runtime: rt,
-                    model,
-                    input_tokens: input as u64,
-                    output_tokens: output as u64,
-                    cache_read_tokens: cache_read.map(|v| v as u64),
-                    cache_write_tokens: cache_write.map(|v| v as u64),
-                    duration_ms: dur.map(|d| d as u64),
-                    created_at: parse_datetime(&created)?,
-                })
-            })
+            .map(
+                |(wid, ws, rt, model, input, output, cache_read, cache_write, dur, created)| {
+                    Ok(TokenUsageRow {
+                        work_id: wid,
+                        workspace: ws,
+                        runtime: rt,
+                        model,
+                        input_tokens: input as u64,
+                        output_tokens: output as u64,
+                        cache_read_tokens: cache_read.map(|v| v as u64),
+                        cache_write_tokens: cache_write.map(|v| v as u64),
+                        duration_ms: dur.map(|d| d as u64),
+                        created_at: parse_datetime(&created)?,
+                    })
+                },
+            )
             .collect()
     }
 }
@@ -799,6 +985,36 @@ fn parse_datetime(s: &str) -> Result<DateTime<Utc>, BeltError> {
     DateTime::parse_from_rfc3339(s)
         .map(|dt| dt.with_timezone(&Utc))
         .map_err(|_| BeltError::Database(format!("invalid datetime: {s}")))
+}
+
+/// Parse a database status string back into a `SpecStatus`.
+///
+/// # Errors
+/// Returns `BeltError::Database` for unrecognised status values.
+fn str_to_spec_status(s: &str) -> Result<SpecStatus, BeltError> {
+    s.parse::<SpecStatus>()
+        .map_err(|_| BeltError::Database(format!("unknown spec status: {s}")))
+}
+
+/// Extract a `Spec` from a rusqlite `Row`.
+///
+/// Column order must match:
+/// `id, workspace_id, name, status, content, priority, labels, depends_on, created_at, updated_at`
+fn row_to_spec(row: &rusqlite::Row<'_>) -> Result<Spec, BeltError> {
+    let status_str: String = row.get(3).map_err(|e| BeltError::Database(e.to_string()))?;
+
+    Ok(Spec {
+        id: row.get(0).map_err(|e| BeltError::Database(e.to_string()))?,
+        workspace_id: row.get(1).map_err(|e| BeltError::Database(e.to_string()))?,
+        name: row.get(2).map_err(|e| BeltError::Database(e.to_string()))?,
+        status: str_to_spec_status(&status_str)?,
+        content: row.get(4).map_err(|e| BeltError::Database(e.to_string()))?,
+        priority: row.get(5).map_err(|e| BeltError::Database(e.to_string()))?,
+        labels: row.get(6).map_err(|e| BeltError::Database(e.to_string()))?,
+        depends_on: row.get(7).map_err(|e| BeltError::Database(e.to_string()))?,
+        created_at: row.get(8).map_err(|e| BeltError::Database(e.to_string()))?,
+        updated_at: row.get(9).map_err(|e| BeltError::Database(e.to_string()))?,
+    })
 }
 
 /// Extract a `QueueItem` from a rusqlite `Row`.
@@ -1174,5 +1390,161 @@ mod tests {
     fn database_is_send_and_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<Database>();
+    }
+
+    // ---- Specs -------------------------------------------------------------
+
+    fn sample_spec() -> Spec {
+        Spec::new(
+            "spec-1".to_string(),
+            "ws-1".to_string(),
+            "Test Spec".to_string(),
+            "Some content".to_string(),
+        )
+    }
+
+    #[test]
+    fn insert_and_get_spec() {
+        let db = test_db();
+        let spec = sample_spec();
+        db.insert_spec(&spec).unwrap();
+
+        let fetched = db.get_spec(&spec.id).unwrap();
+        assert_eq!(fetched.id, spec.id);
+        assert_eq!(fetched.name, "Test Spec");
+        assert_eq!(fetched.status, SpecStatus::Draft);
+        assert_eq!(fetched.content, "Some content");
+    }
+
+    #[test]
+    fn get_spec_not_found() {
+        let db = test_db();
+        let err = db.get_spec("nonexistent").unwrap_err();
+        assert!(matches!(err, BeltError::SpecNotFound(_)));
+    }
+
+    #[test]
+    fn list_specs_no_filter() {
+        let db = test_db();
+        db.insert_spec(&sample_spec()).unwrap();
+
+        let specs = db.list_specs(None, None).unwrap();
+        assert_eq!(specs.len(), 1);
+    }
+
+    #[test]
+    fn list_specs_filter_by_workspace() {
+        let db = test_db();
+        db.insert_spec(&sample_spec()).unwrap();
+
+        let specs = db.list_specs(Some("ws-1"), None).unwrap();
+        assert_eq!(specs.len(), 1);
+
+        let specs = db.list_specs(Some("other"), None).unwrap();
+        assert!(specs.is_empty());
+    }
+
+    #[test]
+    fn list_specs_filter_by_status() {
+        let db = test_db();
+        db.insert_spec(&sample_spec()).unwrap();
+
+        let specs = db.list_specs(None, Some(SpecStatus::Draft)).unwrap();
+        assert_eq!(specs.len(), 1);
+
+        let specs = db.list_specs(None, Some(SpecStatus::Active)).unwrap();
+        assert!(specs.is_empty());
+    }
+
+    #[test]
+    fn update_spec_fields() {
+        let db = test_db();
+        let mut spec = sample_spec();
+        db.insert_spec(&spec).unwrap();
+
+        spec.name = "Updated Name".to_string();
+        spec.content = "Updated content".to_string();
+        spec.priority = Some(1);
+        spec.labels = Some("urgent".to_string());
+        db.update_spec(&spec).unwrap();
+
+        let fetched = db.get_spec(&spec.id).unwrap();
+        assert_eq!(fetched.name, "Updated Name");
+        assert_eq!(fetched.content, "Updated content");
+        assert_eq!(fetched.priority, Some(1));
+        assert_eq!(fetched.labels.as_deref(), Some("urgent"));
+    }
+
+    #[test]
+    fn update_spec_not_found() {
+        let db = test_db();
+        let spec = sample_spec();
+        let err = db.update_spec(&spec).unwrap_err();
+        assert!(matches!(err, BeltError::SpecNotFound(_)));
+    }
+
+    #[test]
+    fn update_spec_status() {
+        let db = test_db();
+        let spec = sample_spec();
+        db.insert_spec(&spec).unwrap();
+
+        db.update_spec_status(&spec.id, SpecStatus::Active).unwrap();
+        let fetched = db.get_spec(&spec.id).unwrap();
+        assert_eq!(fetched.status, SpecStatus::Active);
+    }
+
+    #[test]
+    fn update_spec_status_not_found() {
+        let db = test_db();
+        let err = db
+            .update_spec_status("nonexistent", SpecStatus::Active)
+            .unwrap_err();
+        assert!(matches!(err, BeltError::SpecNotFound(_)));
+    }
+
+    #[test]
+    fn remove_spec() {
+        let db = test_db();
+        let spec = sample_spec();
+        db.insert_spec(&spec).unwrap();
+
+        db.remove_spec(&spec.id).unwrap();
+        assert!(db.get_spec(&spec.id).is_err());
+    }
+
+    #[test]
+    fn remove_spec_not_found() {
+        let db = test_db();
+        let err = db.remove_spec("nonexistent").unwrap_err();
+        assert!(matches!(err, BeltError::SpecNotFound(_)));
+    }
+
+    #[test]
+    fn spec_with_optional_fields() {
+        let db = test_db();
+        let mut spec = sample_spec();
+        spec.priority = Some(5);
+        spec.labels = Some("bug,feature".to_string());
+        spec.depends_on = Some("spec-0".to_string());
+        db.insert_spec(&spec).unwrap();
+
+        let fetched = db.get_spec(&spec.id).unwrap();
+        assert_eq!(fetched.priority, Some(5));
+        assert_eq!(fetched.labels.as_deref(), Some("bug,feature"));
+        assert_eq!(fetched.depends_on.as_deref(), Some("spec-0"));
+    }
+
+    #[test]
+    fn spec_status_roundtrip() {
+        let statuses = [
+            SpecStatus::Draft,
+            SpecStatus::Active,
+            SpecStatus::Paused,
+            SpecStatus::Completed,
+        ];
+        for s in statuses {
+            assert_eq!(str_to_spec_status(s.as_str()).unwrap(), s);
+        }
     }
 }


### PR DESCRIPTION
Closes #63

## Summary
- Add Spec type with state machine (Draft → Active → Paused → Completed)
- Add specs table to DB with full CRUD operations
- Implement 8 CLI subcommands: spec add/list/show/update/pause/resume/complete/remove
- State machine validation enforced on all transitions
- Placeholder for GitHub issue auto-creation on Draft→Active

## Test plan
- [ ] cargo test -p belt-core (12 spec tests)
- [ ] cargo test -p belt-infra (12 DB tests)

Generated with Claude Code