### PR TITLE
feat(daemon): implement evaluate feedback loop with HITL escalation

### DIFF
--- a/crates/belt-daemon/src/cron.rs
+++ b/crates/belt-daemon/src/cron.rs
@@ -3,7 +3,6 @@
 //! Provides a simple interval/daily schedule system and an engine that
 //! ticks through registered jobs, executing those that are due.
 
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -206,10 +205,6 @@ pub struct BuiltinJobDeps {
     pub db: Arc<Database>,
     /// Worktree manager for cleanup operations.
     pub worktree_mgr: Arc<dyn WorktreeManager>,
-    /// Belt home directory for evaluator scripts.
-    pub belt_home: PathBuf,
-    /// Workspace name for evaluate job.
-    pub workspace: String,
 }
 
 /// Expires unanswered HITL (human-in-the-loop) items after a 24-hour timeout.
@@ -356,52 +351,24 @@ impl CronHandler for LogCleanupJob {
     }
 }
 
-/// Evaluates completed queue items by running the evaluate script.
+/// Classifies completed queue items into Done or HITL.
 ///
-/// Scans items in the `Completed` phase, invokes the evaluate script,
-/// and transitions items to `Done` (exit code 0) or `Hitl` (non-zero).
-pub struct EvaluateJob {
-    db: Arc<Database>,
-    belt_home: PathBuf,
-    workspace: String,
-}
+/// This cron job triggers the evaluate cycle via `belt agent -p` invocation
+/// (see [`crate::evaluator::Evaluator::build_evaluate_script`]).
+/// The actual evaluate logic including per-item failure tracking and HITL
+/// escalation is handled by [`crate::daemon::Daemon::evaluate_completed`].
+///
+/// The cron schedule ensures periodic evaluation, while `force_trigger("evaluate")`
+/// is called on every Completed transition for immediate evaluation.
+pub struct EvaluateJob;
 
 impl CronHandler for EvaluateJob {
     fn execute(&self, _ctx: &CronContext) -> Result<(), BeltError> {
-        tracing::info!("EvaluateJob: evaluating completed items");
-
-        let completed_items = self.db.list_items(Some(QueuePhase::Completed), None)?;
-        if completed_items.is_empty() {
-            tracing::debug!("EvaluateJob: no completed items to evaluate");
-            return Ok(());
-        }
-
-        let evaluator = crate::evaluator::Evaluator::new(&self.workspace);
-        let script = evaluator.build_evaluate_script();
-
-        let output = std::process::Command::new("bash")
-            .arg("-c")
-            .arg(&script)
-            .env("WORKSPACE", &self.workspace)
-            .env("BELT_HOME", self.belt_home.to_string_lossy().as_ref())
-            .output()
-            .map_err(|e| BeltError::Runtime(format!("failed to run evaluate script: {e}")))?;
-
-        let exit_code = output.status.code().unwrap_or(-1);
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-
-        if exit_code == 0 {
-            tracing::info!(items = completed_items.len(), "evaluate script succeeded");
-        } else {
-            tracing::warn!(
-                exit_code,
-                stderr = %stderr,
-                stdout = %stdout,
-                "evaluate script returned non-zero exit code"
-            );
-        }
-
+        // The actual evaluate_completed() logic runs in the daemon's async tick.
+        // This cron handler serves as the schedule trigger point.
+        // When the cron engine fires this job, the daemon's next tick will
+        // pick up Completed items and run the evaluator.
+        tracing::info!("EvaluateJob: triggering evaluate cycle for completed items");
         Ok(())
     }
 }
@@ -466,11 +433,7 @@ pub fn builtin_jobs(deps: BuiltinJobDeps) -> Vec<CronJobDef> {
             workspace: None,
             enabled: true,
             last_run_at: None,
-            handler: Box::new(EvaluateJob {
-                db: deps.db,
-                belt_home: deps.belt_home,
-                workspace: deps.workspace,
-            }),
+            handler: Box::new(EvaluateJob),
         },
         CronJobDef {
             name: "pr_review_scan".to_string(),
@@ -542,11 +505,7 @@ pub fn seed_workspace_crons(engine: &mut CronEngine, workspace: &str, deps: Buil
         workspace: Some(ws.clone()),
         enabled: true,
         last_run_at: None,
-        handler: Box::new(EvaluateJob {
-            db: deps.db,
-            belt_home: deps.belt_home,
-            workspace: ws,
-        }),
+        handler: Box::new(EvaluateJob),
     });
 }
 
@@ -753,8 +712,6 @@ mod tests {
         BuiltinJobDeps {
             db,
             worktree_mgr,
-            belt_home: tmp.path().to_path_buf(),
-            workspace: "test-ws".to_string(),
         }
     }
 
@@ -900,17 +857,10 @@ mod tests {
     }
 
     #[test]
-    fn evaluate_job_runs_with_no_completed_items() {
-        let db = Arc::new(Database::open_in_memory().unwrap());
-        let tmp = tempfile::tempdir().unwrap();
-
-        let job = EvaluateJob {
-            db,
-            belt_home: tmp.path().to_path_buf(),
-            workspace: "test-ws".to_string(),
-        };
+    fn evaluate_job_runs_without_error() {
+        let job = EvaluateJob;
         let ctx = CronContext { now: Utc::now() };
-        // Should return Ok when there are no completed items (early return).
+        // EvaluateJob is a trigger-only stub; the actual logic is in Daemon::evaluate_completed.
         job.execute(&ctx).unwrap();
     }
 

--- a/crates/belt-daemon/src/daemon.rs
+++ b/crates/belt-daemon/src/daemon.rs
@@ -52,8 +52,8 @@ pub struct Daemon {
     /// History events with full lineage information for failure tracking.
     history_events: Vec<HistoryEvent>,
     evaluator: Evaluator,
-    /// Cron engine for periodic background jobs (HITL timeout, cleanup, etc.).
-    cron_engine: CronEngine,
+    /// Cron engine for scheduling periodic jobs (evaluate, hitl_timeout, etc.).
+    cron_engine: Option<CronEngine>,
     /// Graceful shutdown 플래그. true이면 새 아이템 수집을 중단한다.
     shutdown_requested: bool,
     /// Evaluator 스크립트 실행을 위한 Belt home 디렉토리.
@@ -101,7 +101,6 @@ impl Daemon {
         max_concurrent: u32,
     ) -> Self {
         let evaluator = Evaluator::new(&config.name);
-        let cron_engine = CronEngine::new();
         Self {
             config,
             sources,
@@ -113,7 +112,7 @@ impl Daemon {
             db: None,
             history_events: Vec::new(),
             evaluator,
-            cron_engine,
+            cron_engine: None,
             shutdown_requested: false,
             belt_home: PathBuf::from(
                 std::env::var("BELT_HOME").unwrap_or_else(|_| ".belt".to_string()),
@@ -129,12 +128,12 @@ impl Daemon {
         let deps = BuiltinJobDeps {
             db: Arc::clone(&db),
             worktree_mgr: Arc::clone(&self.worktree_mgr),
-            belt_home: self.belt_home.clone(),
-            workspace: self.config.name.clone(),
         };
+        let mut cron = self.cron_engine.take().unwrap_or_default();
         for job in builtin_jobs(deps) {
-            self.cron_engine.register(job);
+            cron.register(job);
         }
+        self.cron_engine = Some(cron);
         self.db = Some(db);
         self
     }
@@ -142,6 +141,18 @@ impl Daemon {
     /// Set the belt home directory for evaluator scripts.
     pub fn with_belt_home(mut self, belt_home: PathBuf) -> Self {
         self.belt_home = belt_home;
+        self
+    }
+
+    /// Set the cron engine for periodic job scheduling.
+    pub fn with_cron_engine(mut self, engine: CronEngine) -> Self {
+        self.cron_engine = Some(engine);
+        self
+    }
+
+    /// Set the maximum evaluate failure threshold for HITL escalation.
+    pub fn with_max_eval_failures(mut self, max: u32) -> Self {
+        self.evaluator = Evaluator::new(&self.config.name).with_max_eval_failures(max);
         self
     }
 
@@ -480,6 +491,13 @@ impl Daemon {
                 self.record_history_event(&item, "completed", None);
                 self.tracker.release(&ws_name);
                 self.queue.push_back(item.clone());
+
+                // CR-11: Completed 전이 시 자동 force_trigger("evaluate").
+                if let Some(ref mut engine) = self.cron_engine {
+                    engine.force_trigger("evaluate");
+                    tracing::debug!("force_trigger(evaluate) after Completed: {}", item.work_id);
+                }
+
                 ItemOutcome::Completed(item)
             }
             ExecutionOutcome::Failed { error, result } => {
@@ -705,8 +723,9 @@ impl Daemon {
 
     /// 4단계: Completed 아이템을 evaluator로 평가하여 Done 또는 HITL로 분류.
     ///
-    /// handler 성공 → Completed 전이 후 evaluator가 Done/HITL을 결정한다.
-    /// evaluator 실행 실패 시 Completed 유지, 다음 tick에서 재시도.
+    /// handler 성공 -> Completed 전이 후 evaluator가 Done/HITL을 결정한다.
+    /// evaluator 실행 실패 시 per-item failure count를 증가시키고,
+    /// N회(default 3) 이상 실패 시 자동으로 HITL로 에스컬레이션한다.
     async fn evaluate_completed(&mut self) {
         let completed: Vec<String> = self
             .items_in_phase(QueuePhase::Completed)
@@ -733,7 +752,10 @@ impl Daemon {
 
         match eval_result {
             Ok(result) if result.success() => {
-                // Evaluator 성공 — on_done을 거쳐 Done으로 전이.
+                // Evaluator 성공 -- on_done을 거쳐 Done으로 전이.
+                for work_id in &completed {
+                    self.evaluator.clear_eval_failures(work_id);
+                }
                 for work_id in completed {
                     if let Some(idx) = self.queue.iter().position(|i| i.work_id == work_id) {
                         let mut item = self.queue.remove(idx).unwrap();
@@ -746,48 +768,104 @@ impl Daemon {
                 }
             }
             Ok(result) => {
-                // Evaluator 비정상 종료 — HITL로 라우팅.
+                // Q-07 + Q-14: Evaluator 비정상 종료 -- per-item failure tracking.
+                let error_msg = format!(
+                    "evaluator exit_code={}: {}",
+                    result.exit_code,
+                    result.stderr.trim()
+                );
                 tracing::info!(
-                    "evaluator returned non-zero ({}), routing {} items to HITL",
+                    "evaluator returned non-zero ({}), evaluating {} items for escalation",
                     result.exit_code,
                     completed.len()
                 );
+
+                // Collect decisions first to avoid borrow conflict with self.evaluator.
+                let decisions: Vec<(String, crate::evaluator::EvalDecision)> = completed
+                    .iter()
+                    .map(|work_id| {
+                        let decision = self.evaluator.record_eval_failure(work_id, &error_msg);
+                        (work_id.clone(), decision)
+                    })
+                    .collect();
+
                 let now = chrono::Utc::now().to_rfc3339();
-                for work_id in completed {
-                    if let Some(idx) = self.queue.iter().position(|i| i.work_id == work_id)
+                for (work_id, decision) in decisions {
+                    match decision {
+                        crate::evaluator::EvalDecision::Hitl { reason } => {
+                            // N회 실패 -> HITL 에스컬레이션.
+                            if let Some(idx) = self.queue.iter().position(|i| i.work_id == work_id)
+                                && let Some(item) = self.queue.get_mut(idx)
+                            {
+                                let _ = transit(item, QueuePhase::Hitl);
+                                item.hitl_created_at = Some(now.clone());
+                                item.hitl_reason = Some(HitlReason::EvaluateFailure);
+                                item.hitl_notes = Some(reason.clone());
+                                self.history.push(HistoryEntry {
+                                    source_id: item.source_id.clone(),
+                                    work_id: item.work_id.clone(),
+                                    state: item.state.clone(),
+                                    status: belt_core::context::HistoryStatus::Hitl,
+                                    attempt: self.evaluator.eval_failure_count(&work_id),
+                                    summary: None,
+                                    error: Some(reason),
+                                    created_at: now.clone(),
+                                });
+                            }
+                        }
+                        crate::evaluator::EvalDecision::Retry => {
+                            // Completed 유지, 다음 tick에서 재시도.
+                            tracing::debug!(
+                                "evaluate retry for {} (failure_count={})",
+                                work_id,
+                                self.evaluator.eval_failure_count(&work_id)
+                            );
+                        }
+                        crate::evaluator::EvalDecision::Done => {
+                            // Should not occur from record_eval_failure, but handle gracefully.
+                            self.evaluator.clear_eval_failures(&work_id);
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                // Evaluator 실행 자체가 실패 -- per-item failure tracking with escalation.
+                let error_msg = format!("evaluator execution error: {e}");
+                tracing::warn!(
+                    "evaluator failed for {} completed items: {e}",
+                    completed.len()
+                );
+
+                let decisions: Vec<(String, crate::evaluator::EvalDecision)> = completed
+                    .iter()
+                    .map(|work_id| {
+                        let decision = self.evaluator.record_eval_failure(work_id, &error_msg);
+                        (work_id.clone(), decision)
+                    })
+                    .collect();
+
+                let now = chrono::Utc::now().to_rfc3339();
+                for (work_id, decision) in decisions {
+                    if let crate::evaluator::EvalDecision::Hitl { reason } = decision
+                        && let Some(idx) = self.queue.iter().position(|i| i.work_id == work_id)
                         && let Some(item) = self.queue.get_mut(idx)
                     {
-                        item.phase = QueuePhase::Hitl;
+                        let _ = transit(item, QueuePhase::Hitl);
                         item.hitl_created_at = Some(now.clone());
                         item.hitl_reason = Some(HitlReason::EvaluateFailure);
-                        item.hitl_notes = Some(format!(
-                            "evaluator exit_code={}: {}",
-                            result.exit_code,
-                            result.stderr.trim()
-                        ));
+                        item.hitl_notes = Some(reason.clone());
                         self.history.push(HistoryEntry {
                             source_id: item.source_id.clone(),
                             work_id: item.work_id.clone(),
                             state: item.state.clone(),
                             status: belt_core::context::HistoryStatus::Hitl,
-                            attempt: 0,
+                            attempt: self.evaluator.eval_failure_count(&work_id),
                             summary: None,
-                            error: Some(format!(
-                                "evaluator exit_code={}: {}",
-                                result.exit_code,
-                                result.stderr.trim()
-                            )),
+                            error: Some(reason),
                             created_at: now.clone(),
                         });
                     }
                 }
-            }
-            Err(e) => {
-                // Evaluator 실행 자체가 실패 — Completed 유지, 다음 tick에서 재시도.
-                tracing::warn!(
-                    "evaluator failed for {} completed items, will retry next tick: {e}",
-                    completed.len()
-                );
             }
         }
 
@@ -838,19 +916,18 @@ impl Daemon {
 
         // handler 성공 → Completed 전이 후 force_trigger("evaluate") (D-10).
         // force_trigger는 cron의 last_run_at을 리셋하여 다음 tick에서 즉시 실행.
-        if has_completed {
-            self.cron_engine.force_trigger("evaluate");
+        if has_completed
+            && let Some(ref mut engine) = self.cron_engine
+        {
+            engine.force_trigger("evaluate");
             tracing::debug!("force_trigger(evaluate) after handler completion");
         }
-
-        // Cron engine tick (evaluate, HITL timeout, etc.).
-        self.cron_engine.tick();
 
         // Evaluator로 Completed 아이템 평가 (Done vs HITL).
         self.evaluate_completed().await;
 
         // Cron jobs: HITL timeout, daily report, log cleanup, evaluate 등.
-        self.cron_engine.tick();
+        if let Some(ref mut engine) = self.cron_engine { engine.tick(); }
 
         Ok(())
     }
@@ -2120,7 +2197,7 @@ sources:
         let source = MockDataSource::new("github");
         let mut daemon = setup_daemon(&tmp, source, vec![]);
 
-        let result = daemon.mark_hitl("nonexistent", None);
+        let result = daemon.mark_hitl("nonexistent", HitlReason::ManualEscalation, None);
         assert!(result.is_err());
     }
 
@@ -2132,7 +2209,7 @@ sources:
 
         // Pending → Hitl is not a valid transition.
         daemon.push_item(test_item("s1", "analyze"));
-        let result = daemon.mark_hitl("s1:analyze", Some("reason".into()));
+        let result = daemon.mark_hitl("s1:analyze", HitlReason::ManualEscalation, Some("reason".into()));
         assert!(result.is_err());
         assert_eq!(
             daemon.get_item("s1:analyze").unwrap().phase,

--- a/crates/belt-daemon/src/evaluator.rs
+++ b/crates/belt-daemon/src/evaluator.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::Path;
 
 use anyhow::Result;
@@ -5,23 +6,45 @@ use anyhow::Result;
 use belt_core::phase::QueuePhase;
 use belt_core::queue::QueueItem;
 
+/// Default maximum number of evaluate failures before HITL escalation.
+pub const DEFAULT_MAX_EVAL_FAILURES: u32 = 3;
+
 /// Completed 아이템의 평가 결과.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EvalDecision {
     Done,
-    Hitl { reason: String },
+    Hitl {
+        reason: String,
+    },
+    /// Evaluate 실행 실패 — Completed 유지, 다음 tick에서 재시도.
+    Retry,
 }
 
 /// Completed 아이템을 스캔하여 Done 또는 HITL로 분류.
+///
+/// Per-item evaluate failure count를 추적하며, `max_eval_failures`회
+/// 연속 실패 시 자동으로 HITL로 에스컬레이션한다.
 pub struct Evaluator {
     workspace_name: String,
+    /// Per-item evaluate failure counts (keyed by work_id).
+    eval_failure_counts: HashMap<String, u32>,
+    /// Maximum evaluate failures before HITL escalation.
+    max_eval_failures: u32,
 }
 
 impl Evaluator {
     pub fn new(workspace_name: &str) -> Self {
         Self {
             workspace_name: workspace_name.to_string(),
+            eval_failure_counts: HashMap::new(),
+            max_eval_failures: DEFAULT_MAX_EVAL_FAILURES,
         }
+    }
+
+    /// Set the maximum evaluate failure threshold for HITL escalation.
+    pub fn with_max_eval_failures(mut self, max: u32) -> Self {
+        self.max_eval_failures = max;
+        self
     }
 
     pub fn filter_completed(items: &[QueueItem]) -> Vec<&QueueItem> {
@@ -35,7 +58,55 @@ impl Evaluator {
         match decision {
             EvalDecision::Done => QueuePhase::Done,
             EvalDecision::Hitl { .. } => QueuePhase::Hitl,
+            EvalDecision::Retry => QueuePhase::Completed,
         }
+    }
+
+    /// Record an evaluate failure for the given work_id and return the
+    /// appropriate decision based on accumulated failure count.
+    ///
+    /// If failures >= `max_eval_failures`, escalates to HITL.
+    /// Otherwise, returns `Retry` to keep the item in Completed phase.
+    pub fn record_eval_failure(&mut self, work_id: &str, error: &str) -> EvalDecision {
+        let count = self
+            .eval_failure_counts
+            .entry(work_id.to_string())
+            .or_insert(0);
+        *count += 1;
+
+        tracing::warn!(
+            work_id,
+            eval_failure_count = *count,
+            max = self.max_eval_failures,
+            "evaluate failure recorded"
+        );
+
+        if *count >= self.max_eval_failures {
+            tracing::error!(
+                work_id,
+                eval_failure_count = *count,
+                "escalating to HITL after {} evaluate failures",
+                *count
+            );
+            EvalDecision::Hitl {
+                reason: format!(
+                    "evaluate failed {} times (threshold={}): {}",
+                    *count, self.max_eval_failures, error
+                ),
+            }
+        } else {
+            EvalDecision::Retry
+        }
+    }
+
+    /// Clear the evaluate failure count for a work_id (e.g. on successful evaluation).
+    pub fn clear_eval_failures(&mut self, work_id: &str) {
+        self.eval_failure_counts.remove(work_id);
+    }
+
+    /// Return the current evaluate failure count for a work_id.
+    pub fn eval_failure_count(&self, work_id: &str) -> u32 {
+        self.eval_failure_counts.get(work_id).copied().unwrap_or(0)
     }
 
     pub fn build_evaluate_script(&self) -> String {
@@ -119,11 +190,75 @@ mod tests {
     }
 
     #[test]
+    fn target_phase_retry() {
+        assert_eq!(
+            Evaluator::target_phase(&EvalDecision::Retry),
+            QueuePhase::Completed
+        );
+    }
+
+    #[test]
     fn build_evaluate_script_contains_workspace() {
         let evaluator = Evaluator::new("auth-project");
         let script = evaluator.build_evaluate_script();
         assert!(script.contains("auth-project"));
         assert!(script.contains("belt agent"));
         assert!(script.contains("belt queue done"));
+    }
+
+    #[test]
+    fn record_eval_failure_escalates_after_threshold() {
+        let mut evaluator = Evaluator::new("test-ws").with_max_eval_failures(3);
+
+        // First two failures -> Retry
+        let decision = evaluator.record_eval_failure("item-1", "script error");
+        assert_eq!(decision, EvalDecision::Retry);
+        assert_eq!(evaluator.eval_failure_count("item-1"), 1);
+
+        let decision = evaluator.record_eval_failure("item-1", "script error");
+        assert_eq!(decision, EvalDecision::Retry);
+        assert_eq!(evaluator.eval_failure_count("item-1"), 2);
+
+        // Third failure -> HITL escalation
+        let decision = evaluator.record_eval_failure("item-1", "script error");
+        assert!(matches!(decision, EvalDecision::Hitl { .. }));
+        assert_eq!(evaluator.eval_failure_count("item-1"), 3);
+    }
+
+    #[test]
+    fn clear_eval_failures_resets_count() {
+        let mut evaluator = Evaluator::new("test-ws");
+        evaluator.record_eval_failure("item-1", "error");
+        evaluator.record_eval_failure("item-1", "error");
+        assert_eq!(evaluator.eval_failure_count("item-1"), 2);
+
+        evaluator.clear_eval_failures("item-1");
+        assert_eq!(evaluator.eval_failure_count("item-1"), 0);
+    }
+
+    #[test]
+    fn independent_failure_tracking_per_item() {
+        let mut evaluator = Evaluator::new("test-ws").with_max_eval_failures(2);
+
+        evaluator.record_eval_failure("item-1", "error");
+        evaluator.record_eval_failure("item-2", "error");
+
+        assert_eq!(evaluator.eval_failure_count("item-1"), 1);
+        assert_eq!(evaluator.eval_failure_count("item-2"), 1);
+
+        // item-1 hits threshold
+        let decision = evaluator.record_eval_failure("item-1", "error");
+        assert!(matches!(decision, EvalDecision::Hitl { .. }));
+
+        // item-2 still retrying
+        let decision = evaluator.record_eval_failure("item-2", "error");
+        assert!(matches!(decision, EvalDecision::Hitl { .. }));
+    }
+
+    #[test]
+    fn default_max_eval_failures_is_three() {
+        let evaluator = Evaluator::new("test-ws");
+        assert_eq!(evaluator.max_eval_failures, DEFAULT_MAX_EVAL_FAILURES);
+        assert_eq!(evaluator.max_eval_failures, 3);
     }
 }

--- a/crates/belt-infra/src/sources/github.rs
+++ b/crates/belt-infra/src/sources/github.rs
@@ -448,6 +448,10 @@ sources:
             title: Some("Test issue title".to_string()),
             created_at: "2026-03-24T00:00:00Z".to_string(),
             updated_at: "2026-03-24T00:00:00Z".to_string(),
+            hitl_created_at: None,
+            hitl_respondent: None,
+            hitl_notes: None,
+            hitl_reason: None,
         }
     }
 


### PR DESCRIPTION
Closes #55

## Summary
- Add per-item evaluate failure tracking with configurable threshold (default 3)
- Implement HITL escalation after N consecutive evaluate failures
- Connect force_trigger("evaluate") after handler Completed transitions
- Add EvalDecision::Retry variant for retry-before-escalation flow

## Test plan
- [ ] cargo test -p belt-daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)