### PR TITLE
feat(queue): add worktree preservation tracking and on_fail retry guard

### DIFF
--- a/crates/belt-core/src/queue.rs
+++ b/crates/belt-core/src/queue.rs
@@ -129,6 +129,12 @@ pub struct QueueItem {
     /// HITL 생성 경로.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hitl_reason: Option<HitlReason>,
+    /// Worktree가 보존되었는지 여부.
+    ///
+    /// HITL 또는 Failed 전이 시 `true`로 설정되어 worktree가
+    /// cleanup 없이 보존되었음을 명시적으로 기록한다.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub worktree_preserved: bool,
 }
 
 impl QueueItem {
@@ -147,6 +153,7 @@ impl QueueItem {
             hitl_respondent: None,
             hitl_notes: None,
             hitl_reason: None,
+            worktree_preserved: false,
         }
     }
 
@@ -172,6 +179,7 @@ pub struct QueueItemRow {
     pub hitl_respondent: Option<String>,
     pub hitl_notes: Option<String>,
     pub hitl_reason: Option<String>,
+    pub worktree_preserved: bool,
 }
 
 impl QueueItem {
@@ -189,6 +197,7 @@ impl QueueItem {
             hitl_respondent: self.hitl_respondent.clone(),
             hitl_notes: self.hitl_notes.clone(),
             hitl_reason: self.hitl_reason.map(|r| r.to_string()),
+            worktree_preserved: self.worktree_preserved,
         }
     }
 
@@ -218,7 +227,16 @@ impl QueueItem {
             hitl_respondent: row.hitl_respondent.clone(),
             hitl_notes: row.hitl_notes.clone(),
             hitl_reason,
+            worktree_preserved: row.worktree_preserved,
         })
+    }
+
+    /// Mark that the worktree is preserved (not cleaned up).
+    ///
+    /// Called when transitioning to HITL or Failed to record that the
+    /// worktree remains on disk for debugging or human review.
+    pub fn mark_worktree_preserved(&mut self) {
+        self.worktree_preserved = true;
     }
 }
 
@@ -241,6 +259,7 @@ pub mod testing {
             hitl_respondent: None,
             hitl_notes: None,
             hitl_reason: None,
+            worktree_preserved: false,
         }
     }
 }
@@ -336,5 +355,42 @@ mod tests {
             HitlReason::ManualEscalation.to_string(),
             "manual_escalation"
         );
+    }
+
+    fn worktree_preserved_default_false() {
+        let item = test_item("s1", "analyze");
+        assert!(!item.worktree_preserved);
+    }
+
+    #[test]
+    fn mark_worktree_preserved_sets_flag() {
+        let mut item = test_item("s1", "analyze");
+        item.mark_worktree_preserved();
+        assert!(item.worktree_preserved);
+    }
+
+    #[test]
+    fn worktree_preserved_skipped_in_json_when_false() {
+        let item = test_item("s1", "analyze");
+        let json = serde_json::to_string(&item).unwrap();
+        assert!(!json.contains("worktree_preserved"));
+    }
+
+    #[test]
+    fn worktree_preserved_present_in_json_when_true() {
+        let mut item = test_item("s1", "analyze");
+        item.mark_worktree_preserved();
+        let json = serde_json::to_string(&item).unwrap();
+        assert!(json.contains("\"worktree_preserved\":true"));
+    }
+
+    #[test]
+    fn worktree_preserved_row_roundtrip() {
+        let mut item = test_item("s1", "analyze");
+        item.mark_worktree_preserved();
+        let row = item.to_row();
+        assert!(row.worktree_preserved);
+        let restored = QueueItem::from_row(&row).unwrap();
+        assert!(restored.worktree_preserved);
     }
 }

--- a/crates/belt-daemon/src/cron.rs
+++ b/crates/belt-daemon/src/cron.rs
@@ -193,8 +193,8 @@ impl Default for CronEngine {
 // Built-in jobs
 // ---------------------------------------------------------------------------
 
-/// HITL timeout threshold (24 hours).
-const HITL_TIMEOUT_HOURS: i64 = 24;
+/// Default HITL timeout duration (24 hours).
+const DEFAULT_HITL_TIMEOUT_SECS: i64 = 24 * 60 * 60;
 
 /// Worktree TTL for log cleanup (7 days).
 const WORKTREE_TTL_DAYS: i64 = 7;
@@ -207,13 +207,34 @@ pub struct BuiltinJobDeps {
     pub worktree_mgr: Arc<dyn WorktreeManager>,
 }
 
-/// Expires unanswered HITL (human-in-the-loop) items after a 24-hour timeout.
+/// Expires unanswered HITL (human-in-the-loop) items after a configurable timeout.
 ///
 /// Queries items in the `Hitl` phase, checks their `updated_at` timestamp,
-/// and transitions those older than 24 hours to `Failed`.
+/// and transitions those older than the configured timeout to `Failed`.
+/// Also cleans up the associated worktree on expiry.
 pub struct HitlTimeoutJob {
     db: Arc<Database>,
     worktree_mgr: Arc<dyn WorktreeManager>,
+    /// Timeout duration in seconds. Items in HITL phase longer than this
+    /// are considered expired. Defaults to 24 hours.
+    pub timeout_secs: i64,
+}
+
+impl HitlTimeoutJob {
+    /// Create a new `HitlTimeoutJob` with the default timeout (24 hours).
+    pub fn new(db: Arc<Database>, worktree_mgr: Arc<dyn WorktreeManager>) -> Self {
+        Self {
+            db,
+            worktree_mgr,
+            timeout_secs: DEFAULT_HITL_TIMEOUT_SECS,
+        }
+    }
+
+    /// Set the timeout duration in seconds.
+    pub fn with_timeout_secs(mut self, secs: i64) -> Self {
+        self.timeout_secs = secs;
+        self
+    }
 }
 
 impl CronHandler for HitlTimeoutJob {
@@ -221,7 +242,7 @@ impl CronHandler for HitlTimeoutJob {
         tracing::info!("HitlTimeoutJob: checking for expired HITL items");
 
         let hitl_items = self.db.list_items(Some(QueuePhase::Hitl), None)?;
-        let threshold = ctx.now - chrono::Duration::hours(HITL_TIMEOUT_HOURS);
+        let threshold = ctx.now - chrono::Duration::seconds(self.timeout_secs);
         let mut expired_count = 0u32;
 
         for item in &hitl_items {
@@ -251,8 +272,8 @@ impl CronHandler for HitlTimeoutJob {
                 expired_count += 1;
                 tracing::info!(
                     work_id = %item.work_id,
-                    "HITL item expired after {} hours",
-                    HITL_TIMEOUT_HOURS
+                    "HITL item expired after {} seconds, transitioned to Failed",
+                    self.timeout_secs
                 );
             }
         }
@@ -401,10 +422,10 @@ pub fn builtin_jobs(deps: BuiltinJobDeps) -> Vec<CronJobDef> {
             workspace: None,
             enabled: true,
             last_run_at: None,
-            handler: Box::new(HitlTimeoutJob {
-                db: Arc::clone(&deps.db),
-                worktree_mgr: Arc::clone(&deps.worktree_mgr),
-            }),
+            handler: Box::new(HitlTimeoutJob::new(
+                Arc::clone(&deps.db),
+                Arc::clone(&deps.worktree_mgr),
+            )),
         },
         CronJobDef {
             name: "daily_report".to_string(),
@@ -470,10 +491,10 @@ pub fn seed_workspace_crons(engine: &mut CronEngine, workspace: &str, deps: Buil
         workspace: Some(ws.clone()),
         enabled: true,
         last_run_at: None,
-        handler: Box::new(HitlTimeoutJob {
-            db: Arc::clone(&deps.db),
-            worktree_mgr: Arc::clone(&deps.worktree_mgr),
-        }),
+        handler: Box::new(HitlTimeoutJob::new(
+            Arc::clone(&deps.db),
+            Arc::clone(&deps.worktree_mgr),
+        )),
     });
 
     engine.register(CronJobDef {
@@ -757,10 +778,7 @@ mod tests {
         // We need to set phase via DB since insert_item sets it from the struct.
         // Items are already in Hitl phase from the struct.
 
-        let job = HitlTimeoutJob {
-            db: Arc::clone(&db),
-            worktree_mgr,
-        };
+        let job = HitlTimeoutJob::new(Arc::clone(&db), worktree_mgr);
         let ctx = CronContext { now: Utc::now() };
         job.execute(&ctx).unwrap();
 

--- a/crates/belt-daemon/src/daemon.rs
+++ b/crates/belt-daemon/src/daemon.rs
@@ -76,6 +76,10 @@ struct ExecutionResult {
     item: QueueItem,
     outcome: ExecutionOutcome,
     ws_name: String,
+    /// on_fail actions from the state config, deferred for escalation-aware execution.
+    on_fail_actions: Vec<Action>,
+    /// worktree path for on_fail script execution.
+    worktree: Option<PathBuf>,
 }
 
 enum ExecutionOutcome {
@@ -309,19 +313,7 @@ impl Daemon {
         while let Some(result) = join_set.join_next().await {
             match result {
                 Ok(exec_result) => {
-                    let outcome = self.apply_execution_result(exec_result);
-
-                    // Execute on_fail scripts based on escalation policy.
-                    if let ItemOutcome::Failed {
-                        ref item,
-                        escalation,
-                        ..
-                    } = outcome
-                        && escalation.should_run_on_fail()
-                    {
-                        self.execute_on_fail_for_item(item).await;
-                    }
-
+                    let outcome = self.apply_execution_result(exec_result).await;
                     outcomes.push(outcome);
                 }
                 Err(e) => {
@@ -333,34 +325,6 @@ impl Daemon {
         outcomes
     }
 
-    /// Execute on_fail scripts for a failed item (best-effort).
-    ///
-    /// Escalation policy의 `should_run_on_fail()`이 true일 때만 호출된다.
-    /// silent retry는 on_fail을 실행하지 않는다.
-    async fn execute_on_fail_for_item(&self, item: &QueueItem) {
-        let state_config = match self.find_state_config(&item.state).cloned() {
-            Some(cfg) => cfg,
-            None => return,
-        };
-
-        if state_config.on_fail.is_empty() {
-            return;
-        }
-
-        let worktree = match self.worktree_mgr.create_or_reuse(&item.work_id) {
-            Ok(path) => path,
-            Err(e) => {
-                tracing::warn!("on_fail worktree error for {}: {e}", item.work_id);
-                return;
-            }
-        };
-
-        let env = ActionEnv::new(&item.work_id, &worktree);
-        let on_fail: Vec<Action> = state_config.on_fail.iter().map(Action::from).collect();
-        if let Err(e) = self.executor.execute_all(&on_fail, &env).await {
-            tracing::warn!("on_fail execution error for {}: {e}", item.work_id);
-        }
-    }
 
     /// 단일 아이템의 handler를 실행하는 순수 async 함수.
     /// `&mut self` 의존 없이 `tokio::spawn`으로 실행 가능하다.
@@ -379,9 +343,14 @@ impl Daemon {
                     item,
                     outcome: ExecutionOutcome::Skipped,
                     ws_name,
+                    on_fail_actions: Vec::new(),
+                    worktree: None,
                 };
             }
         };
+
+        // Collect on_fail actions for deferred, escalation-aware execution.
+        let on_fail_actions: Vec<Action> = state_config.on_fail.iter().map(Action::from).collect();
 
         let worktree = match worktree_mgr.create_or_reuse(&ws_name) {
             Ok(path) => path,
@@ -393,6 +362,8 @@ impl Daemon {
                         error: format!("worktree creation failed: {e}"),
                     },
                     ws_name,
+                    on_fail_actions: Vec::new(),
+                    worktree: None,
                 };
             }
         };
@@ -411,6 +382,8 @@ impl Daemon {
                         result: None,
                     },
                     ws_name,
+                    on_fail_actions,
+                    worktree: Some(worktree),
                 };
             }
             Err(e) => {
@@ -423,6 +396,8 @@ impl Daemon {
                         result: None,
                     },
                     ws_name,
+                    on_fail_actions,
+                    worktree: Some(worktree),
                 };
             }
             _ => {
@@ -442,6 +417,8 @@ impl Daemon {
                     result: Some(r),
                 },
                 ws_name,
+                on_fail_actions,
+                worktree: Some(worktree),
             },
             Ok(r) => {
                 item.phase = QueuePhase::Completed;
@@ -449,6 +426,8 @@ impl Daemon {
                     item,
                     outcome: ExecutionOutcome::Completed { result: r },
                     ws_name,
+                    on_fail_actions: Vec::new(),
+                    worktree: Some(worktree),
                 }
             }
             Err(e) => {
@@ -460,17 +439,24 @@ impl Daemon {
                         result: None,
                     },
                     ws_name,
+                    on_fail_actions,
+                    worktree: Some(worktree),
                 }
             }
         }
     }
 
     /// 병렬 실행 결과를 daemon 상태에 반영한다.
-    fn apply_execution_result(&mut self, exec_result: ExecutionResult) -> ItemOutcome {
+    ///
+    /// Q-12: on_fail scripts are only executed when the escalation action
+    /// is not a silent retry (`EscalationAction::Retry`).
+    async fn apply_execution_result(&mut self, exec_result: ExecutionResult) -> ItemOutcome {
         let ExecutionResult {
             mut item,
             outcome,
             ws_name,
+            on_fail_actions,
+            worktree,
         } = exec_result;
 
         match outcome {
@@ -508,8 +494,36 @@ impl Daemon {
                 let failure_count = self.count_failures(&item.source_id, &item.state);
                 let escalation = self.resolve_escalation(&item.state, failure_count + 1);
 
+                // Q-12: Execute on_fail scripts only when escalation is not a silent retry.
+                if escalation.should_run_on_fail() {
+                    if let Some(ref wt) = worktree {
+                        let env = ActionEnv::new(&item.work_id, wt);
+                        if let Err(e) = self.executor.execute_all(&on_fail_actions, &env).await {
+                            tracing::warn!(
+                                work_id = %item.work_id,
+                                "on_fail script execution error: {e}"
+                            );
+                        }
+                    }
+                } else {
+                    tracing::debug!(
+                        work_id = %item.work_id,
+                        escalation = ?escalation,
+                        "skipping on_fail execution for silent retry"
+                    );
+                }
+
                 self.record_history(&item, "failed", Some(&error));
                 self.record_history_event(&item, "failed", Some(error.clone()));
+
+                // Q-10: Mark worktree as preserved for Failed items.
+                item.mark_worktree_preserved();
+                tracing::info!(
+                    work_id = %item.work_id,
+                    phase = "failed",
+                    "worktree preserved for failed item"
+                );
+
                 self.handle_escalation(&mut item, escalation);
                 self.tracker.release(&ws_name);
 
@@ -622,6 +636,8 @@ impl Daemon {
     }
 
     /// Mark a Running item as Failed and record a HistoryEvent.
+    ///
+    /// Also marks the worktree as preserved so it remains available for debugging.
     pub fn mark_failed(&mut self, work_id: &str, error: String) -> Result<(), BeltError> {
         let item = self
             .queue
@@ -633,6 +649,8 @@ impl Daemon {
         let state = item.state.clone();
 
         transit(item, QueuePhase::Failed)?;
+        item.mark_worktree_preserved();
+        tracing::info!(work_id, "worktree preserved for failed item");
 
         let attempt = self.count_failures(&source_id, &state) + 1;
 
@@ -851,6 +869,13 @@ impl Daemon {
                         && let Some(item) = self.queue.get_mut(idx)
                     {
                         let _ = transit(item, QueuePhase::Hitl);
+                        // Q-10: Mark worktree as preserved for HITL items.
+                        item.mark_worktree_preserved();
+                        tracing::info!(
+                            work_id = %item.work_id,
+                            phase = "hitl",
+                            "worktree preserved for HITL item"
+                        );
                         item.hitl_created_at = Some(now.clone());
                         item.hitl_reason = Some(HitlReason::EvaluateFailure);
                         item.hitl_notes = Some(reason.clone());
@@ -922,6 +947,7 @@ impl Daemon {
             engine.force_trigger("evaluate");
             tracing::debug!("force_trigger(evaluate) after handler completion");
         }
+
 
         // Evaluator로 Completed 아이템 평가 (Done vs HITL).
         self.evaluate_completed().await;

--- a/crates/belt-infra/src/db.rs
+++ b/crates/belt-infra/src/db.rs
@@ -1237,6 +1237,7 @@ fn row_to_queue_item(row: &rusqlite::Row<'_>) -> Result<QueueItem, BeltError> {
             .get(10)
             .map_err(|e| BeltError::Database(e.to_string()))?,
         hitl_reason,
+        worktree_preserved: false,
     })
 }
 
@@ -1262,6 +1263,7 @@ mod tests {
             hitl_respondent: None,
             hitl_notes: None,
             hitl_reason: None,
+            worktree_preserved: false,
         }
     }
 

--- a/crates/belt-infra/src/sources/github.rs
+++ b/crates/belt-infra/src/sources/github.rs
@@ -255,6 +255,7 @@ impl GitHubDataSource {
                 hitl_respondent: None,
                 hitl_notes: None,
                 hitl_reason: None,
+                worktree_preserved: false,
             });
         }
 
@@ -341,6 +342,7 @@ impl DataSource for GitHubDataSource {
                             hitl_respondent: None,
                             hitl_notes: None,
                             hitl_reason: None,
+                            worktree_preserved: false,
                         });
                     }
                 }
@@ -452,6 +454,7 @@ sources:
             hitl_respondent: None,
             hitl_notes: None,
             hitl_reason: None,
+            worktree_preserved: false,
         }
     }
 


### PR DESCRIPTION
Closes #56

## Summary
- Add worktree_preserved field to QueueItem for explicit preservation tracking
- Implement on_fail retry guard (skip on_fail during silent retries)
- Implement HitlTimeoutJob with 24h configurable timeout
- Mark worktree as preserved on HITL/Failed transitions with tracing logs

## Test plan
- [ ] cargo test -p belt-daemon -p belt-core -p belt-infra

🤖 Generated with [Claude Code](https://claude.com/claude-code)