### PR TITLE
feat(cron): add BELT_DB env var and per-workspace cron seed generation

### DIFF
--- a/crates/belt-daemon/src/cron.rs
+++ b/crates/belt-daemon/src/cron.rs
@@ -472,6 +472,73 @@ pub fn builtin_jobs(deps: BuiltinJobDeps) -> Vec<CronJobDef> {
 }
 
 // ---------------------------------------------------------------------------
+// Per-workspace cron seed
+// ---------------------------------------------------------------------------
+
+/// Seed built-in cron jobs for a specific workspace.
+///
+/// Creates workspace-scoped instances of the standard jobs with the
+/// intervals specified in the issue requirements:
+/// - `HitlTimeoutJob` — every 1 hour
+/// - `DailyReportJob` — every 24 hours
+/// - `LogCleanupJob` — every 6 hours
+/// - `EvaluateJob` — every 60 seconds
+///
+/// The `deps` parameter provides the shared dependencies (DB, worktree manager,
+/// belt home, workspace name) used to initialise each job handler.
+pub fn seed_workspace_crons(engine: &mut CronEngine, workspace: &str, deps: BuiltinJobDeps) {
+    let ws = workspace.to_string();
+
+    engine.register(CronJobDef {
+        name: format!("{ws}:hitl_timeout"),
+        schedule: CronSchedule::Interval(Duration::from_secs(3600)),
+        workspace: Some(ws.clone()),
+        enabled: true,
+        last_run_at: None,
+        handler: Box::new(HitlTimeoutJob {
+            db: Arc::clone(&deps.db),
+            worktree_mgr: Arc::clone(&deps.worktree_mgr),
+        }),
+    });
+
+    engine.register(CronJobDef {
+        name: format!("{ws}:daily_report"),
+        schedule: CronSchedule::Interval(Duration::from_secs(86400)),
+        workspace: Some(ws.clone()),
+        enabled: true,
+        last_run_at: None,
+        handler: Box::new(DailyReportJob {
+            db: Arc::clone(&deps.db),
+        }),
+    });
+
+    engine.register(CronJobDef {
+        name: format!("{ws}:log_cleanup"),
+        schedule: CronSchedule::Interval(Duration::from_secs(21600)),
+        workspace: Some(ws.clone()),
+        enabled: true,
+        last_run_at: None,
+        handler: Box::new(LogCleanupJob {
+            db: Arc::clone(&deps.db),
+            worktree_mgr: Arc::clone(&deps.worktree_mgr),
+        }),
+    });
+
+    engine.register(CronJobDef {
+        name: format!("{ws}:evaluate"),
+        schedule: CronSchedule::Interval(Duration::from_secs(60)),
+        workspace: Some(ws.clone()),
+        enabled: true,
+        last_run_at: None,
+        handler: Box::new(EvaluateJob {
+            db: deps.db,
+            belt_home: deps.belt_home,
+            workspace: ws,
+        }),
+    });
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -836,5 +903,61 @@ mod tests {
         let ctx = CronContext { now: Utc::now() };
         // Should return Ok when there are no completed items (early return).
         job.execute(&ctx).unwrap();
+    }
+
+    // -- seed_workspace_crons tests --
+
+    #[test]
+    fn seed_workspace_crons_registers_four_jobs() {
+        let mut engine = CronEngine::new();
+        let deps = make_test_deps();
+        seed_workspace_crons(&mut engine, "my-project", deps);
+        assert_eq!(engine.job_count(), 4);
+    }
+
+    #[test]
+    fn seed_workspace_crons_names_are_scoped() {
+        let mut engine = CronEngine::new();
+        let deps = make_test_deps();
+        seed_workspace_crons(&mut engine, "auth", deps);
+
+        // Verify all job names are workspace-scoped.
+        let names: Vec<&str> = engine.jobs.iter().map(|j| j.name.as_str()).collect();
+        assert!(names.contains(&"auth:hitl_timeout"));
+        assert!(names.contains(&"auth:daily_report"));
+        assert!(names.contains(&"auth:log_cleanup"));
+        assert!(names.contains(&"auth:evaluate"));
+    }
+
+    #[test]
+    fn seed_workspace_crons_sets_workspace_field() {
+        let mut engine = CronEngine::new();
+        let deps = make_test_deps();
+        seed_workspace_crons(&mut engine, "billing", deps);
+
+        for job in &engine.jobs {
+            assert_eq!(job.workspace.as_deref(), Some("billing"));
+        }
+    }
+
+    #[test]
+    fn seed_workspace_crons_multiple_workspaces_coexist() {
+        let mut engine = CronEngine::new();
+        let deps1 = make_test_deps();
+        let deps2 = make_test_deps();
+        seed_workspace_crons(&mut engine, "alpha", deps1);
+        seed_workspace_crons(&mut engine, "beta", deps2);
+        assert_eq!(engine.job_count(), 8);
+    }
+
+    #[test]
+    fn seed_workspace_crons_idempotent() {
+        let mut engine = CronEngine::new();
+        let deps1 = make_test_deps();
+        let deps2 = make_test_deps();
+        seed_workspace_crons(&mut engine, "ws", deps1);
+        seed_workspace_crons(&mut engine, "ws", deps2);
+        // register() replaces by name, so should still be 4.
+        assert_eq!(engine.job_count(), 4);
     }
 }

--- a/crates/belt-daemon/src/evaluator.rs
+++ b/crates/belt-daemon/src/evaluator.rs
@@ -53,11 +53,13 @@ belt agent --workspace "{ws}" -p \
 
     pub async fn run_evaluate(&self, belt_home: &Path) -> Result<EvaluateResult> {
         let script = self.build_evaluate_script();
+        let belt_db = belt_home.join("belt.db");
         let output = tokio::process::Command::new("bash")
             .arg("-c")
             .arg(&script)
             .env("WORKSPACE", &self.workspace_name)
             .env("BELT_HOME", belt_home.to_string_lossy().as_ref())
+            .env("BELT_DB", belt_db.to_string_lossy().as_ref())
             .output()
             .await?;
 

--- a/crates/belt-daemon/src/executor.rs
+++ b/crates/belt-daemon/src/executor.rs
@@ -136,6 +136,16 @@ impl ActionExecutor {
         cmd.current_dir(&env.worktree);
         cmd.env("WORK_ID", &env.work_id);
         cmd.env("WORKTREE", env.worktree.to_string_lossy().as_ref());
+        // Inject BELT_DB path derived from BELT_HOME (or extra_vars override).
+        if let Some(belt_db) = env.extra_vars.get("BELT_DB") {
+            cmd.env("BELT_DB", belt_db);
+        } else if let Some(belt_home) = env.extra_vars.get("BELT_HOME") {
+            let db_path = Path::new(belt_home).join("belt.db");
+            cmd.env("BELT_DB", db_path.to_string_lossy().as_ref());
+        } else if let Ok(belt_home) = std::env::var("BELT_HOME") {
+            let db_path = Path::new(&belt_home).join("belt.db");
+            cmd.env("BELT_DB", db_path.to_string_lossy().as_ref());
+        }
         for (k, v) in &env.extra_vars {
             cmd.env(k, v);
         }


### PR DESCRIPTION
Closes #68

## Summary
- Inject BELT_DB environment variable in script/evaluate execution
- Add seed_workspace_crons() for per-workspace cron job registration
- Wire seed into workspace add CLI command
- Workspace-scoped job names (e.g. my-project:hitl_timeout)

## Test plan
- [ ] cargo test -p belt-daemon -p belt-cli

🤖 Generated with [Claude Code](https://claude.com/claude-code)