### PR TITLE
feat(dashboard): implement TUI dashboard, transition events, and spec status

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,10 @@ clap = { version = "4", features = ["derive"] }
 # Database
 rusqlite = { version = "0.32", features = ["bundled"] }
 
+# TUI
+ratatui = "0.29"
+crossterm = "0.28"
+
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/belt-cli/Cargo.toml
+++ b/crates/belt-cli/Cargo.toml
@@ -23,6 +23,8 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 chrono = { workspace = true }
 dirs = "6"
+ratatui = { workspace = true }
+crossterm = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/belt-cli/src/dashboard.rs
+++ b/crates/belt-cli/src/dashboard.rs
@@ -1,9 +1,250 @@
-//! TUI dashboard rendering for Belt.
+//! TUI Dashboard and runtime statistics panel for Belt.
 //!
-//! Provides a runtime statistics panel that displays token usage,
-//! average execution duration, and per-model breakdowns.
+//! Provides two display modes:
+//! - `run()`: interactive ratatui-based real-time TUI dashboard (3-panel layout)
+//! - `render_runtime_panel()`: text-based runtime statistics panel for non-TUI output
 
-use belt_infra::db::RuntimeStats;
+use std::io;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use crossterm::execute;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
+
+use belt_core::phase::QueuePhase;
+use belt_infra::db::{Database, RuntimeStats};
+
+/// Run the interactive TUI dashboard.
+///
+/// The dashboard refreshes every second and exits on `q` or `Esc`.
+pub fn run(db: Arc<Database>) -> anyhow::Result<()> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let result = run_loop(&mut terminal, &db);
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+
+    result
+}
+
+fn run_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    db: &Database,
+) -> anyhow::Result<()> {
+    loop {
+        terminal.draw(|frame| {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Length(5),
+                    Constraint::Min(8),
+                    Constraint::Length(10),
+                ])
+                .split(frame.area());
+
+            // Top: phase summary
+            let summary = render_phase_summary(db);
+            frame.render_widget(summary, chunks[0]);
+
+            // Middle: running items
+            let running = render_running_items(db);
+            frame.render_widget(running, chunks[1]);
+
+            // Bottom: recent completed/failed
+            let recent = render_recent_items(db);
+            frame.render_widget(recent, chunks[2]);
+        })?;
+
+        // Poll for keyboard events with 1 second timeout
+        if event::poll(Duration::from_secs(1))?
+            && let Event::Key(key) = event::read()?
+            && key.kind == KeyEventKind::Press
+            && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc)
+        {
+            return Ok(());
+        }
+    }
+}
+
+fn render_phase_summary(db: &Database) -> Paragraph<'static> {
+    let counts = db.count_items_by_phase().unwrap_or_default();
+    let mut spans: Vec<Span<'static>> = Vec::new();
+
+    let all_phases = [
+        "pending",
+        "ready",
+        "running",
+        "completed",
+        "done",
+        "hitl",
+        "failed",
+        "skipped",
+    ];
+
+    for (i, phase) in all_phases.iter().enumerate() {
+        let count = counts
+            .iter()
+            .find(|(p, _)| p == phase)
+            .map(|(_, c)| *c)
+            .unwrap_or(0);
+
+        let color = phase_color(phase);
+        if i > 0 {
+            spans.push(Span::raw("  "));
+        }
+        spans.push(Span::styled(
+            format!("{phase}: {count}"),
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ));
+    }
+
+    let total: u32 = counts.iter().map(|(_, c)| *c).sum();
+    spans.push(Span::raw("  "));
+    spans.push(Span::styled(
+        format!("total: {total}"),
+        Style::default().add_modifier(Modifier::BOLD),
+    ));
+
+    Paragraph::new(Line::from(spans)).block(
+        Block::default()
+            .title(" Phase Summary ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan)),
+    )
+}
+
+fn render_running_items(db: &Database) -> Table<'static> {
+    let items = db
+        .list_items(Some(QueuePhase::Running), None)
+        .unwrap_or_default();
+
+    let rows: Vec<Row<'static>> = items
+        .into_iter()
+        .map(|item| {
+            Row::new(vec![
+                Cell::from(item.work_id),
+                Cell::from(item.workspace_id),
+                Cell::from(item.state),
+                Cell::from(item.updated_at),
+            ])
+        })
+        .collect();
+
+    let header = Row::new(vec!["Work ID", "Workspace", "State", "Updated"])
+        .style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )
+        .bottom_margin(1);
+
+    Table::new(
+        rows,
+        [
+            Constraint::Percentage(35),
+            Constraint::Percentage(20),
+            Constraint::Percentage(20),
+            Constraint::Percentage(25),
+        ],
+    )
+    .header(header)
+    .block(
+        Block::default()
+            .title(" Running Items ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Green)),
+    )
+}
+
+fn render_recent_items(db: &Database) -> Table<'static> {
+    let done_items = db
+        .list_items(Some(QueuePhase::Done), None)
+        .unwrap_or_default();
+    let failed_items = db
+        .list_items(Some(QueuePhase::Failed), None)
+        .unwrap_or_default();
+    let completed_items = db
+        .list_items(Some(QueuePhase::Completed), None)
+        .unwrap_or_default();
+
+    let mut all_items: Vec<_> = done_items
+        .into_iter()
+        .chain(failed_items)
+        .chain(completed_items)
+        .collect();
+
+    // Sort by updated_at descending, take latest 8
+    all_items.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    all_items.truncate(8);
+
+    let rows: Vec<Row<'static>> = all_items
+        .into_iter()
+        .map(|item| {
+            let phase_str = item.phase.as_str().to_string();
+            let color = phase_color(&phase_str);
+            Row::new(vec![
+                Cell::from(item.work_id),
+                Cell::from(phase_str).style(Style::default().fg(color)),
+                Cell::from(item.workspace_id),
+                Cell::from(item.updated_at),
+            ])
+        })
+        .collect();
+
+    let header = Row::new(vec!["Work ID", "Phase", "Workspace", "Updated"])
+        .style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )
+        .bottom_margin(1);
+
+    Table::new(
+        rows,
+        [
+            Constraint::Percentage(35),
+            Constraint::Percentage(15),
+            Constraint::Percentage(20),
+            Constraint::Percentage(30),
+        ],
+    )
+    .header(header)
+    .block(
+        Block::default()
+            .title(" Recent Completed/Failed ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Magenta)),
+    )
+}
+
+fn phase_color(phase: &str) -> Color {
+    match phase {
+        "pending" => Color::Gray,
+        "ready" => Color::Blue,
+        "running" => Color::Green,
+        "completed" => Color::Cyan,
+        "done" => Color::White,
+        "hitl" => Color::Yellow,
+        "failed" => Color::Red,
+        "skipped" => Color::DarkGray,
+        _ => Color::White,
+    }
+}
 
 /// Render the runtime statistics panel to stdout.
 ///

--- a/crates/belt-cli/src/main.rs
+++ b/crates/belt-cli/src/main.rs
@@ -9,6 +9,8 @@ use belt_infra::db::Database;
 
 mod agent;
 mod bootstrap;
+mod dashboard;
+mod status;
 
 use belt_core::runtime::RuntimeRegistry;
 use belt_daemon::daemon::Daemon;
@@ -47,10 +49,12 @@ enum Commands {
     Stop,
     /// Show system status.
     Status {
-        /// Output format.
+        /// Output format (text, json, rich).
         #[arg(long, default_value = "text")]
         format: String,
     },
+    /// Open the real-time TUI dashboard.
+    Dashboard,
     /// Workspace management.
     Workspace {
         #[command(subcommand)]
@@ -211,6 +215,14 @@ enum QueueCommands {
 
 #[derive(Subcommand)]
 enum SpecCommands {
+    /// Show workspace status (item counts by phase).
+    Status {
+        /// Workspace name.
+        name: String,
+        /// Output format (text, json, rich).
+        #[arg(long, default_value = "text")]
+        format: String,
+    },
     /// Add a new spec.
     Add {
         /// Workspace ID.
@@ -686,6 +698,19 @@ async fn main() -> anyhow::Result<()> {
         Commands::Status { format } => {
             cmd_status(&format)?;
         }
+        Commands::Dashboard => {
+            let belt_home = dirs::home_dir()
+                .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?
+                .join(".belt");
+            std::fs::create_dir_all(&belt_home)?;
+            let db_path = belt_home.join("belt.db");
+            let db = std::sync::Arc::new(belt_infra::db::Database::open(
+                db_path
+                    .to_str()
+                    .ok_or_else(|| anyhow::anyhow!("invalid db path"))?,
+            )?);
+            dashboard::run(db)?;
+        }
         Commands::Workspace { command } => {
             let belt_home = dirs::home_dir()
                 .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?
@@ -872,6 +897,10 @@ async fn main() -> anyhow::Result<()> {
             )?;
 
             match command {
+                SpecCommands::Status { name, format } => {
+                    let spec_status = status::gather_spec_status(&db, &name)?;
+                    status::print_spec_status(&spec_status, &format)?;
+                }
                 SpecCommands::Add {
                     workspace,
                     name,

--- a/crates/belt-cli/src/status.rs
+++ b/crates/belt-cli/src/status.rs
@@ -1,57 +1,175 @@
-//! Status display for `belt status`.
+//! Status display for `belt status` and `belt spec status`.
 //!
 //! Supports `text`, `json`, and `rich` output formats.
 //! The `rich` format includes runtime statistics alongside system status.
 
+use belt_core::phase::QueuePhase;
 use belt_infra::db::{Database, RuntimeStats};
 use serde::Serialize;
 
 use crate::dashboard;
 
-/// Summary payload for JSON output.
-#[derive(Serialize)]
-struct StatusOutput {
-    status: &'static str,
-    runtime_stats: Option<RuntimeStats>,
+/// System status summary returned by `belt status`.
+#[derive(Debug, Serialize)]
+pub struct SystemStatus {
+    pub total_items: u32,
+    pub phase_counts: Vec<PhaseCount>,
+    pub running_items: Vec<ItemSummary>,
+    pub recent_events: Vec<EventSummary>,
+    pub runtime_stats: Option<RuntimeStats>,
+}
+
+/// Count of items in a specific phase.
+#[derive(Debug, Serialize)]
+pub struct PhaseCount {
+    pub phase: String,
+    pub count: u32,
+}
+
+/// Brief summary of a queue item.
+#[derive(Debug, Serialize)]
+pub struct ItemSummary {
+    pub work_id: String,
+    pub workspace: String,
+    pub state: String,
+    pub phase: String,
+    pub updated_at: String,
+}
+
+/// Brief summary of a transition event.
+#[derive(Debug, Serialize)]
+pub struct EventSummary {
+    pub item_id: String,
+    pub from_state: String,
+    pub to_state: String,
+    pub event_type: String,
+    pub timestamp: String,
+}
+
+/// Workspace spec status.
+#[derive(Debug, Serialize)]
+pub struct SpecStatus {
+    pub workspace: String,
+    pub config_path: String,
+    pub item_count: u32,
+    pub phase_counts: Vec<PhaseCount>,
 }
 
 /// Display system status in the requested format.
+///
+/// Opens the default Belt database automatically.
 ///
 /// # Errors
 /// Returns an error if the database cannot be opened or queried.
 pub fn show_status(format: &str) -> anyhow::Result<()> {
     let db = open_db()?;
-    let stats = db.get_runtime_stats().ok();
+    let sys_status = gather_status(&db)?;
+    print_status(&sys_status, format)
+}
 
+/// Gather system status from the database.
+pub fn gather_status(db: &Database) -> anyhow::Result<SystemStatus> {
+    let phase_counts_raw = db.count_items_by_phase()?;
+    let total_items: u32 = phase_counts_raw.iter().map(|(_, c)| *c).sum();
+
+    let phase_counts = phase_counts_raw
+        .into_iter()
+        .map(|(phase, count)| PhaseCount { phase, count })
+        .collect();
+
+    let running = db.list_items(Some(QueuePhase::Running), None)?;
+    let running_items = running
+        .into_iter()
+        .map(|item| ItemSummary {
+            work_id: item.work_id,
+            workspace: item.workspace_id,
+            state: item.state,
+            phase: item.phase.as_str().to_string(),
+            updated_at: item.updated_at,
+        })
+        .collect();
+
+    let events = db.list_recent_transition_events(10)?;
+    let recent_events = events
+        .into_iter()
+        .map(|e| EventSummary {
+            item_id: e.item_id,
+            from_state: e.from_state,
+            to_state: e.to_state,
+            event_type: e.event_type,
+            timestamp: e.timestamp,
+        })
+        .collect();
+
+    let runtime_stats = db.get_runtime_stats().ok();
+
+    Ok(SystemStatus {
+        total_items,
+        phase_counts,
+        running_items,
+        recent_events,
+        runtime_stats,
+    })
+}
+
+/// Gather spec (workspace) status from the database.
+pub fn gather_spec_status(db: &Database, workspace: &str) -> anyhow::Result<SpecStatus> {
+    let (name, config_path, _created_at) = db.get_workspace(workspace)?;
+
+    let all_items = db.list_items(None, Some(workspace))?;
+    let item_count = all_items.len() as u32;
+
+    let mut counts = std::collections::HashMap::<String, u32>::new();
+    for item in &all_items {
+        *counts.entry(item.phase.as_str().to_string()).or_insert(0) += 1;
+    }
+
+    let mut phase_counts: Vec<PhaseCount> = counts
+        .into_iter()
+        .map(|(phase, count)| PhaseCount { phase, count })
+        .collect();
+    phase_counts.sort_by(|a, b| a.phase.cmp(&b.phase));
+
+    Ok(SpecStatus {
+        workspace: name,
+        config_path,
+        item_count,
+        phase_counts,
+    })
+}
+
+/// Print system status in the requested format.
+pub fn print_status(status: &SystemStatus, format: &str) -> anyhow::Result<()> {
     match format {
         "json" => {
-            let output = StatusOutput {
-                status: "ok",
-                runtime_stats: stats,
-            };
-            println!("{}", serde_json::to_string_pretty(&output)?);
+            println!("{}", serde_json::to_string_pretty(status)?);
         }
         "rich" => {
-            println!("Belt System Status: OK");
-            println!();
-            if let Some(ref s) = stats {
+            print_rich_status(status);
+            if let Some(ref s) = status.runtime_stats {
                 dashboard::render_runtime_panel(s);
-            } else {
-                println!("  Runtime stats: unavailable");
             }
         }
         _ => {
-            // Default text format.
-            println!("Belt System Status: OK");
-            if let Some(ref s) = stats {
-                println!(
-                    "  Tokens (24h): {} total, {} executions",
-                    s.total_tokens, s.executions
-                );
-            }
+            print_text_status(status);
         }
     }
+    Ok(())
+}
 
+/// Print spec status in the requested format.
+pub fn print_spec_status(status: &SpecStatus, format: &str) -> anyhow::Result<()> {
+    match format {
+        "json" => {
+            println!("{}", serde_json::to_string_pretty(status)?);
+        }
+        "rich" => {
+            print_rich_spec_status(status);
+        }
+        _ => {
+            print_text_spec_status(status);
+        }
+    }
     Ok(())
 }
 
@@ -67,4 +185,111 @@ fn open_db() -> anyhow::Result<Database> {
             .ok_or_else(|| anyhow::anyhow!("invalid database path"))?,
     )?;
     Ok(db)
+}
+
+fn print_text_status(status: &SystemStatus) {
+    println!("Belt System Status");
+    println!("==================");
+    println!("Total items: {}", status.total_items);
+    println!();
+    if !status.phase_counts.is_empty() {
+        println!("Phase breakdown:");
+        for pc in &status.phase_counts {
+            println!("  {:<12} {}", pc.phase, pc.count);
+        }
+        println!();
+    }
+    if status.running_items.is_empty() {
+        println!("No items currently running.");
+    } else {
+        println!("Running items:");
+        for item in &status.running_items {
+            println!("  {} ({}/{})", item.work_id, item.workspace, item.state);
+        }
+    }
+    println!();
+    if !status.recent_events.is_empty() {
+        println!("Recent transitions:");
+        for ev in &status.recent_events {
+            println!(
+                "  {} -> {} [{}] {} ({})",
+                ev.from_state, ev.to_state, ev.event_type, ev.item_id, ev.timestamp
+            );
+        }
+    }
+    if let Some(ref s) = status.runtime_stats {
+        println!();
+        println!(
+            "  Tokens (24h): {} total, {} executions",
+            s.total_tokens, s.executions
+        );
+    }
+}
+
+fn print_rich_status(status: &SystemStatus) {
+    println!("+--------------------------------------+");
+    println!("|        Belt System Status            |");
+    println!("+--------------------------------------+");
+    println!("| Total items: {:<23} |", status.total_items);
+    println!("+--------------------------------------+");
+    if !status.phase_counts.is_empty() {
+        println!("| Phase          | Count               |");
+        println!("+----------------+---------------------+");
+        for pc in &status.phase_counts {
+            println!("| {:<14} | {:<19} |", pc.phase, pc.count);
+        }
+        println!("+----------------+---------------------+");
+    }
+
+    if !status.running_items.is_empty() {
+        println!();
+        println!("+-- Running Items ----------------------+");
+        for item in &status.running_items {
+            println!(
+                "| {:<36} |",
+                format!("{} ({})", item.work_id, item.workspace)
+            );
+        }
+        println!("+--------------------------------------+");
+    }
+
+    if !status.recent_events.is_empty() {
+        println!();
+        println!("+-- Recent Transitions -----------------+");
+        for ev in &status.recent_events {
+            println!("| {} -> {} [{}]", ev.from_state, ev.to_state, ev.event_type);
+        }
+        println!("+--------------------------------------+");
+    }
+}
+
+fn print_text_spec_status(status: &SpecStatus) {
+    println!("Workspace: {}", status.workspace);
+    println!("Config:    {}", status.config_path);
+    println!("Items:     {}", status.item_count);
+    println!();
+    if status.phase_counts.is_empty() {
+        println!("No items in this workspace.");
+    } else {
+        println!("Phase breakdown:");
+        for pc in &status.phase_counts {
+            println!("  {:<12} {}", pc.phase, pc.count);
+        }
+    }
+}
+
+fn print_rich_spec_status(status: &SpecStatus) {
+    println!("+--------------------------------------+");
+    println!("| Workspace: {:<25} |", status.workspace);
+    println!("| Config:    {:<25} |", status.config_path);
+    println!("| Items:     {:<25} |", status.item_count);
+    println!("+--------------------------------------+");
+    if !status.phase_counts.is_empty() {
+        println!("| Phase          | Count               |");
+        println!("+----------------+---------------------+");
+        for pc in &status.phase_counts {
+            println!("| {:<14} | {:<19} |", pc.phase, pc.count);
+        }
+        println!("+----------------+---------------------+");
+    }
 }

--- a/crates/belt-infra/src/db.rs
+++ b/crates/belt-infra/src/db.rs
@@ -99,6 +99,25 @@ pub struct TokenUsageRow {
     pub created_at: DateTime<Utc>,
 }
 
+/// A transition event recording a state change for a queue item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransitionEvent {
+    /// Unique event identifier.
+    pub id: String,
+    /// The queue item this transition belongs to.
+    pub item_id: String,
+    /// Phase before the transition.
+    pub from_state: String,
+    /// Phase after the transition.
+    pub to_state: String,
+    /// Type of event (e.g. "phase_change", "manual", "auto").
+    pub event_type: String,
+    /// When this transition occurred (RFC 3339).
+    pub timestamp: String,
+    /// Optional JSON metadata.
+    pub metadata: Option<String>,
+}
+
 /// Per-model aggregated statistics from the `token_usage` table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelStats {
@@ -253,6 +272,16 @@ impl Database {
                 depends_on   TEXT,
                 created_at   TEXT NOT NULL,
                 updated_at   TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS transition_events (
+                id         TEXT PRIMARY KEY,
+                item_id    TEXT NOT NULL,
+                from_state TEXT NOT NULL,
+                to_state   TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                timestamp  TEXT NOT NULL,
+                metadata   TEXT
             );
             ",
         )
@@ -432,6 +461,30 @@ impl Database {
 
         // Unwrap the inner Results produced by row_to_queue_item.
         items.into_iter().collect::<Result<Vec<_>, _>>()
+    }
+
+    /// Count queue items grouped by phase.
+    ///
+    /// Returns a list of `(phase_string, count)` tuples.
+    pub fn count_items_by_phase(&self) -> Result<Vec<(String, u32)>, BeltError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        let mut stmt = conn
+            .prepare("SELECT phase, COUNT(*) FROM queue_items GROUP BY phase ORDER BY phase")
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+
+        let rows = stmt
+            .query_map([], |row| {
+                let phase: String = row.get(0)?;
+                let count: u32 = row.get(1)?;
+                Ok((phase, count))
+            })
+            .map_err(|e| BeltError::Database(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        Ok(rows)
     }
 
     // ---- History -----------------------------------------------------------
@@ -1018,6 +1071,98 @@ impl Database {
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| BeltError::Database(e.to_string()))?;
         Ok(entries)
+    }
+
+    // ---- Transition Events -------------------------------------------------
+
+    /// Record a transition event.
+    pub fn insert_transition_event(&self, event: &TransitionEvent) -> Result<(), BeltError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        conn.execute(
+            "INSERT INTO transition_events (id, item_id, from_state, to_state, event_type, timestamp, metadata)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                event.id,
+                event.item_id,
+                event.from_state,
+                event.to_state,
+                event.event_type,
+                event.timestamp,
+                event.metadata,
+            ],
+        )
+        .map_err(|e| BeltError::Database(e.to_string()))?;
+        Ok(())
+    }
+
+    /// List transition events for a given item, ordered by timestamp ascending.
+    pub fn list_transition_events(&self, item_id: &str) -> Result<Vec<TransitionEvent>, BeltError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, item_id, from_state, to_state, event_type, timestamp, metadata
+                 FROM transition_events WHERE item_id = ?1 ORDER BY timestamp ASC",
+            )
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+
+        let events = stmt
+            .query_map(params![item_id], |row| {
+                Ok(TransitionEvent {
+                    id: row.get(0)?,
+                    item_id: row.get(1)?,
+                    from_state: row.get(2)?,
+                    to_state: row.get(3)?,
+                    event_type: row.get(4)?,
+                    timestamp: row.get(5)?,
+                    metadata: row.get(6)?,
+                })
+            })
+            .map_err(|e| BeltError::Database(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        Ok(events)
+    }
+
+    /// List the most recent transition events across all items.
+    ///
+    /// Returns up to `limit` events ordered by timestamp descending.
+    pub fn list_recent_transition_events(
+        &self,
+        limit: u32,
+    ) -> Result<Vec<TransitionEvent>, BeltError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, item_id, from_state, to_state, event_type, timestamp, metadata
+                 FROM transition_events ORDER BY timestamp DESC LIMIT ?1",
+            )
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+
+        let events = stmt
+            .query_map(params![limit], |row| {
+                Ok(TransitionEvent {
+                    id: row.get(0)?,
+                    item_id: row.get(1)?,
+                    from_state: row.get(2)?,
+                    to_state: row.get(3)?,
+                    event_type: row.get(4)?,
+                    timestamp: row.get(5)?,
+                    metadata: row.get(6)?,
+                })
+            })
+            .map_err(|e| BeltError::Database(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        Ok(events)
     }
 
     // ---- Token Usage -------------------------------------------------------
@@ -2103,4 +2248,79 @@ mod tests {
         assert_eq!(expired.len(), 1);
         assert_eq!(expired[0], old_item.work_id);
     }
+
+    // ---- Transition Events tests -------------------------------------------
+
+    #[test]
+    fn insert_and_list_transition_events() {
+        let db = test_db();
+        let ev = TransitionEvent {
+            id: "ev1".to_string(),
+            item_id: "w1".to_string(),
+            from_state: "pending".to_string(),
+            to_state: "running".to_string(),
+            event_type: "phase_change".to_string(),
+            timestamp: Utc::now().to_rfc3339(),
+            metadata: None,
+        };
+        db.insert_transition_event(&ev).unwrap();
+
+        let events = db.list_transition_events("w1").unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].id, "ev1");
+        assert_eq!(events[0].from_state, "pending");
+        assert_eq!(events[0].to_state, "running");
+    }
+
+    #[test]
+    fn list_recent_transition_events_respects_limit() {
+        let db = test_db();
+        for i in 0..5 {
+            let ev = TransitionEvent {
+                id: format!("ev{i}"),
+                item_id: format!("w{i}"),
+                from_state: "pending".to_string(),
+                to_state: "running".to_string(),
+                event_type: "phase_change".to_string(),
+                timestamp: Utc::now().to_rfc3339(),
+                metadata: None,
+            };
+            db.insert_transition_event(&ev).unwrap();
+        }
+        let recent = db.list_recent_transition_events(3).unwrap();
+        assert_eq!(recent.len(), 3);
+    }
+
+    #[test]
+    fn count_items_by_phase_empty() {
+        let db = test_db();
+        let counts = db.count_items_by_phase().unwrap();
+        assert!(counts.is_empty());
+    }
+
+    #[test]
+    fn count_items_by_phase_with_items() {
+        let db = test_db();
+        let mut item1 = sample_item();
+        item1.work_id = "w1".to_string();
+        item1.phase = QueuePhase::Pending;
+        db.insert_item(&item1).unwrap();
+
+        let mut item2 = sample_item();
+        item2.work_id = "w2".to_string();
+        item2.phase = QueuePhase::Running;
+        db.insert_item(&item2).unwrap();
+
+        let mut item3 = sample_item();
+        item3.work_id = "w3".to_string();
+        item3.phase = QueuePhase::Pending;
+        db.insert_item(&item3).unwrap();
+
+        let counts = db.count_items_by_phase().unwrap();
+        let pending = counts.iter().find(|(p, _)| p == "pending").map(|(_, c)| *c);
+        let running = counts.iter().find(|(p, _)| p == "running").map(|(_, c)| *c);
+        assert_eq!(pending, Some(2));
+        assert_eq!(running, Some(1));
+    }
+
 }

--- a/crates/belt-infra/src/sources/github.rs
+++ b/crates/belt-infra/src/sources/github.rs
@@ -242,21 +242,14 @@ impl GitHubDataSource {
             let source_id = format!("github:{repo_name}!{number}");
             let work_id = QueueItem::make_work_id(&source_id, review_scan_state);
 
-            items.push(QueueItem {
+            let mut item = QueueItem::new(
                 work_id,
                 source_id,
-                workspace_id: workspace.name.clone(),
-                state: review_scan_state.to_string(),
-                phase: QueuePhase::Pending,
-                title: Some(format!("[review] {title}")),
-                created_at: chrono::Utc::now().to_rfc3339(),
-                updated_at: chrono::Utc::now().to_rfc3339(),
-                hitl_created_at: None,
-                hitl_respondent: None,
-                hitl_notes: None,
-                hitl_reason: None,
-                worktree_preserved: false,
-            });
+                workspace.name.clone(),
+                review_scan_state.to_string(),
+            );
+            item.title = Some(format!("[review] {title}"));
+            items.push(item);
         }
 
         Ok(items)
@@ -441,21 +434,14 @@ sources:
 
     fn make_queue_item(source_id: &str, state: &str) -> QueueItem {
         let work_id = QueueItem::make_work_id(source_id, state);
-        QueueItem {
+        let mut item = QueueItem::new(
             work_id,
-            source_id: source_id.to_string(),
-            workspace_id: "test-ws".to_string(),
-            state: state.to_string(),
-            phase: QueuePhase::Pending,
-            title: Some("Test issue title".to_string()),
-            created_at: "2026-03-24T00:00:00Z".to_string(),
-            updated_at: "2026-03-24T00:00:00Z".to_string(),
-            hitl_created_at: None,
-            hitl_respondent: None,
-            hitl_notes: None,
-            hitl_reason: None,
-            worktree_preserved: false,
-        }
+            source_id.to_string(),
+            "test-ws".to_string(),
+            state.to_string(),
+        );
+        item.title = Some("Test issue title".to_string());
+        item
     }
 
     // ── extract_repo_name ────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #65

## Summary
- Add ratatui-based TUI dashboard (3-panel layout, 1s refresh)
- Implement belt status with text/json/rich formats
- Implement belt spec status
- Add transition_events DB table with CRUD operations
- Add ratatui 0.29 and crossterm 0.28 dependencies

## Test plan
- [ ] cargo test -p belt-cli -p belt-infra

🤖 Generated with [Claude Code](https://claude.com/claude-code)