### PR TITLE
feat(dashboard): add runtime stats panel with token/duration/model aggregation

### DIFF
--- a/crates/belt-cli/Cargo.toml
+++ b/crates/belt-cli/Cargo.toml
@@ -14,6 +14,7 @@ belt-core = { workspace = true }
 belt-infra = { workspace = true }
 belt-daemon = { workspace = true }
 clap = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 tokio = { workspace = true }

--- a/crates/belt-cli/src/dashboard.rs
+++ b/crates/belt-cli/src/dashboard.rs
@@ -1,0 +1,93 @@
+//! TUI dashboard rendering for Belt.
+//!
+//! Provides a runtime statistics panel that displays token usage,
+//! average execution duration, and per-model breakdowns.
+
+use belt_infra::db::RuntimeStats;
+
+/// Render the runtime statistics panel to stdout.
+///
+/// Displays overall token totals, execution count, average duration,
+/// and a per-model breakdown table.
+pub fn render_runtime_panel(stats: &RuntimeStats) {
+    println!("=== Runtime Stats (last 24h) ===");
+    println!();
+    println!(
+        "  Total tokens:  {} (in: {} / out: {})",
+        format_number(stats.total_tokens),
+        format_number(stats.total_tokens_input),
+        format_number(stats.total_tokens_output),
+    );
+    println!("  Executions:    {}", stats.executions);
+    match stats.avg_duration_ms {
+        Some(d) => println!("  Avg duration:  {:.0}ms", d),
+        None => println!("  Avg duration:  -"),
+    }
+
+    if !stats.by_model.is_empty() {
+        println!();
+        println!(
+            "  {:<20} {:>10} {:>10} {:>10} {:>6} {:>10}",
+            "Model", "Input", "Output", "Total", "Runs", "Avg ms"
+        );
+        println!("  {}", "-".repeat(70));
+
+        let mut models: Vec<_> = stats.by_model.values().collect();
+        models.sort_by(|a, b| b.total_tokens.cmp(&a.total_tokens));
+
+        for m in models {
+            let avg = m
+                .avg_duration_ms
+                .map_or_else(|| "-".to_string(), |d| format!("{d:.0}"));
+            println!(
+                "  {:<20} {:>10} {:>10} {:>10} {:>6} {:>10}",
+                m.model,
+                format_number(m.input_tokens),
+                format_number(m.output_tokens),
+                format_number(m.total_tokens),
+                m.executions,
+                avg,
+            );
+        }
+    }
+
+    println!();
+}
+
+/// Format a number with comma-separated thousands for readability.
+fn format_number(n: u64) -> String {
+    if n < 1_000 {
+        return n.to_string();
+    }
+    let s = n.to_string();
+    let mut result = String::with_capacity(s.len() + s.len() / 3);
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result.chars().rev().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_number_small() {
+        assert_eq!(format_number(0), "0");
+        assert_eq!(format_number(999), "999");
+    }
+
+    #[test]
+    fn format_number_thousands() {
+        assert_eq!(format_number(1_000), "1,000");
+        assert_eq!(format_number(1_234_567), "1,234,567");
+    }
+
+    #[test]
+    fn format_number_millions() {
+        assert_eq!(format_number(10_000_000), "10,000,000");
+    }
+}

--- a/crates/belt-cli/src/main.rs
+++ b/crates/belt-cli/src/main.rs
@@ -1,6 +1,8 @@
 use clap::{Parser, Subcommand};
 
 mod claw;
+mod dashboard;
+mod status;
 
 #[derive(Parser)]
 #[command(
@@ -138,8 +140,7 @@ async fn main() -> anyhow::Result<()> {
             // TODO: daemon stop
         }
         Commands::Status { format } => {
-            tracing::info!(format, "showing status...");
-            // TODO: status display
+            status::show_status(&format)?;
         }
         Commands::Workspace { command } => match command {
             WorkspaceCommands::Add { config } => {

--- a/crates/belt-cli/src/status.rs
+++ b/crates/belt-cli/src/status.rs
@@ -1,0 +1,70 @@
+//! Status display for `belt status`.
+//!
+//! Supports `text`, `json`, and `rich` output formats.
+//! The `rich` format includes runtime statistics alongside system status.
+
+use belt_infra::db::{Database, RuntimeStats};
+use serde::Serialize;
+
+use crate::dashboard;
+
+/// Summary payload for JSON output.
+#[derive(Serialize)]
+struct StatusOutput {
+    status: &'static str,
+    runtime_stats: Option<RuntimeStats>,
+}
+
+/// Display system status in the requested format.
+///
+/// # Errors
+/// Returns an error if the database cannot be opened or queried.
+pub fn show_status(format: &str) -> anyhow::Result<()> {
+    let db = open_db()?;
+    let stats = db.get_runtime_stats().ok();
+
+    match format {
+        "json" => {
+            let output = StatusOutput {
+                status: "ok",
+                runtime_stats: stats,
+            };
+            println!("{}", serde_json::to_string_pretty(&output)?);
+        }
+        "rich" => {
+            println!("Belt System Status: OK");
+            println!();
+            if let Some(ref s) = stats {
+                dashboard::render_runtime_panel(s);
+            } else {
+                println!("  Runtime stats: unavailable");
+            }
+        }
+        _ => {
+            // Default text format.
+            println!("Belt System Status: OK");
+            if let Some(ref s) = stats {
+                println!(
+                    "  Tokens (24h): {} total, {} executions",
+                    s.total_tokens, s.executions
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Open the Belt database from the default location (`~/.belt/belt.db`).
+fn open_db() -> anyhow::Result<Database> {
+    let belt_home = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?
+        .join(".belt");
+    let db_path = belt_home.join("belt.db");
+    let db = Database::open(
+        db_path
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("invalid database path"))?,
+    )?;
+    Ok(db)
+}

--- a/crates/belt-infra/src/db.rs
+++ b/crates/belt-infra/src/db.rs
@@ -3,6 +3,7 @@
 //! Provides CRUD operations for queue items, history events, workspaces,
 //! cron jobs, and token usage — all backed by a single SQLite database.
 
+use std::collections::HashMap;
 use std::sync::Mutex;
 
 use chrono::{DateTime, Utc};
@@ -75,6 +76,40 @@ pub struct TokenUsageRow {
     pub duration_ms: Option<u64>,
     /// Timestamp when the usage was recorded.
     pub created_at: DateTime<Utc>,
+}
+
+/// Per-model aggregated statistics from the `token_usage` table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelStats {
+    /// Model identifier.
+    pub model: String,
+    /// Total input tokens consumed by this model.
+    pub input_tokens: u64,
+    /// Total output tokens produced by this model.
+    pub output_tokens: u64,
+    /// Combined input + output tokens for this model.
+    pub total_tokens: u64,
+    /// Number of invocations recorded for this model.
+    pub executions: u64,
+    /// Average wall-clock duration in milliseconds (only from rows that have a value).
+    pub avg_duration_ms: Option<f64>,
+}
+
+/// Aggregated runtime statistics across all models.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeStats {
+    /// Total input tokens across all models.
+    pub total_tokens_input: u64,
+    /// Total output tokens across all models.
+    pub total_tokens_output: u64,
+    /// Grand total of input + output tokens.
+    pub total_tokens: u64,
+    /// Total number of runtime invocations.
+    pub executions: u64,
+    /// Average wall-clock duration in milliseconds across all invocations.
+    pub avg_duration_ms: Option<f64>,
+    /// Per-model breakdown.
+    pub by_model: HashMap<String, ModelStats>,
 }
 
 /// SQLite-backed persistence for Belt state.
@@ -683,20 +718,22 @@ impl Database {
             .map_err(|e| BeltError::Database(e.to_string()))?;
 
         rows.into_iter()
-            .map(|(wid, ws, rt, model, input, output, cache_read, cache_write, dur, created)| {
-                Ok(TokenUsageRow {
-                    work_id: wid,
-                    workspace: ws,
-                    runtime: rt,
-                    model,
-                    input_tokens: input as u64,
-                    output_tokens: output as u64,
-                    cache_read_tokens: cache_read.map(|v| v as u64),
-                    cache_write_tokens: cache_write.map(|v| v as u64),
-                    duration_ms: dur.map(|d| d as u64),
-                    created_at: parse_datetime(&created)?,
-                })
-            })
+            .map(
+                |(wid, ws, rt, model, input, output, cache_read, cache_write, dur, created)| {
+                    Ok(TokenUsageRow {
+                        work_id: wid,
+                        workspace: ws,
+                        runtime: rt,
+                        model,
+                        input_tokens: input as u64,
+                        output_tokens: output as u64,
+                        cache_read_tokens: cache_read.map(|v| v as u64),
+                        cache_write_tokens: cache_write.map(|v| v as u64),
+                        duration_ms: dur.map(|d| d as u64),
+                        created_at: parse_datetime(&created)?,
+                    })
+                },
+            )
             .collect()
     }
 
@@ -739,21 +776,111 @@ impl Database {
             .map_err(|e| BeltError::Database(e.to_string()))?;
 
         rows.into_iter()
-            .map(|(wid, ws, rt, model, input, output, cache_read, cache_write, dur, created)| {
-                Ok(TokenUsageRow {
-                    work_id: wid,
-                    workspace: ws,
-                    runtime: rt,
-                    model,
-                    input_tokens: input as u64,
-                    output_tokens: output as u64,
-                    cache_read_tokens: cache_read.map(|v| v as u64),
-                    cache_write_tokens: cache_write.map(|v| v as u64),
-                    duration_ms: dur.map(|d| d as u64),
-                    created_at: parse_datetime(&created)?,
-                })
-            })
+            .map(
+                |(wid, ws, rt, model, input, output, cache_read, cache_write, dur, created)| {
+                    Ok(TokenUsageRow {
+                        work_id: wid,
+                        workspace: ws,
+                        runtime: rt,
+                        model,
+                        input_tokens: input as u64,
+                        output_tokens: output as u64,
+                        cache_read_tokens: cache_read.map(|v| v as u64),
+                        cache_write_tokens: cache_write.map(|v| v as u64),
+                        duration_ms: dur.map(|d| d as u64),
+                        created_at: parse_datetime(&created)?,
+                    })
+                },
+            )
             .collect()
+    }
+
+    /// Aggregate runtime statistics from the last 24 hours, grouped by model.
+    ///
+    /// Returns overall totals and a per-model breakdown of token usage,
+    /// execution count, and average duration.
+    pub fn get_runtime_stats(&self) -> Result<RuntimeStats, BeltError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+
+        let cutoff = (Utc::now() - chrono::Duration::hours(24)).to_rfc3339();
+
+        let mut stmt = conn
+            .prepare(
+                "SELECT model,
+                        SUM(input_tokens)  AS total_input,
+                        SUM(output_tokens) AS total_output,
+                        COUNT(*)           AS exec_count,
+                        AVG(duration_ms)   AS avg_dur
+                 FROM token_usage
+                 WHERE created_at >= ?1
+                 GROUP BY model
+                 ORDER BY model",
+            )
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+
+        let model_rows = stmt
+            .query_map(params![cutoff], |row| {
+                let model: String = row.get(0)?;
+                let input: i64 = row.get(1)?;
+                let output: i64 = row.get(2)?;
+                let count: i64 = row.get(3)?;
+                let avg_dur: Option<f64> = row.get(4)?;
+                Ok((model, input, output, count, avg_dur))
+            })
+            .map_err(|e| BeltError::Database(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+
+        let mut total_input: u64 = 0;
+        let mut total_output: u64 = 0;
+        let mut total_executions: u64 = 0;
+        let mut duration_sum: f64 = 0.0;
+        let mut duration_count: u64 = 0;
+        let mut by_model = HashMap::new();
+
+        for (model, input, output, count, avg_dur) in model_rows {
+            let inp = input as u64;
+            let out = output as u64;
+            let cnt = count as u64;
+            total_input += inp;
+            total_output += out;
+            total_executions += cnt;
+
+            if let Some(d) = avg_dur {
+                duration_sum += d * cnt as f64;
+                duration_count += cnt;
+            }
+
+            by_model.insert(
+                model.clone(),
+                ModelStats {
+                    model,
+                    input_tokens: inp,
+                    output_tokens: out,
+                    total_tokens: inp + out,
+                    executions: cnt,
+                    avg_duration_ms: avg_dur,
+                },
+            );
+        }
+
+        let avg_duration_ms = if duration_count > 0 {
+            Some(duration_sum / duration_count as f64)
+        } else {
+            None
+        };
+
+        Ok(RuntimeStats {
+            total_tokens_input: total_input,
+            total_tokens_output: total_output,
+            total_tokens: total_input + total_output,
+            executions: total_executions,
+            avg_duration_ms,
+            by_model,
+        })
     }
 }
 
@@ -1168,6 +1295,53 @@ mod tests {
     fn parse_datetime_invalid_returns_error() {
         let err = parse_datetime("not-a-date").unwrap_err();
         assert!(matches!(err, BeltError::Database(_)));
+    }
+
+    #[test]
+    fn get_runtime_stats_empty() {
+        let db = test_db();
+        let stats = db.get_runtime_stats().unwrap();
+        assert_eq!(stats.total_tokens, 0);
+        assert_eq!(stats.executions, 0);
+        assert!(stats.avg_duration_ms.is_none());
+        assert!(stats.by_model.is_empty());
+    }
+
+    #[test]
+    fn get_runtime_stats_aggregates_by_model() {
+        let db = test_db();
+        let usage_a = TokenUsage {
+            input_tokens: 1000,
+            output_tokens: 500,
+            ..Default::default()
+        };
+        let usage_b = TokenUsage {
+            input_tokens: 200,
+            output_tokens: 100,
+            ..Default::default()
+        };
+        db.record_token_usage("w1", "ws1", "claude", "opus-4", &usage_a, Some(2000))
+            .unwrap();
+        db.record_token_usage("w2", "ws1", "claude", "opus-4", &usage_a, Some(3000))
+            .unwrap();
+        db.record_token_usage("w3", "ws1", "claude", "sonnet-4", &usage_b, Some(500))
+            .unwrap();
+
+        let stats = db.get_runtime_stats().unwrap();
+        assert_eq!(stats.total_tokens_input, 2200);
+        assert_eq!(stats.total_tokens_output, 1100);
+        assert_eq!(stats.total_tokens, 3300);
+        assert_eq!(stats.executions, 3);
+        assert!(stats.avg_duration_ms.is_some());
+
+        let opus = stats.by_model.get("opus-4").unwrap();
+        assert_eq!(opus.executions, 2);
+        assert_eq!(opus.input_tokens, 2000);
+        assert_eq!(opus.total_tokens, 3000);
+
+        let sonnet = stats.by_model.get("sonnet-4").unwrap();
+        assert_eq!(sonnet.executions, 1);
+        assert_eq!(sonnet.total_tokens, 300);
     }
 
     #[test]


### PR DESCRIPTION
Closes #78

## Summary
- Add RuntimeStats and ModelStats types with 24h aggregation query
- Add runtime panel to dashboard (total tokens, avg duration, per-model table)
- Implement belt status with text/json/rich formats including runtime stats
- Register dashboard and status modules in CLI

## Test plan
- [ ] cargo test -p belt-cli -p belt-infra

🤖 Generated with [Claude Code](https://claude.com/claude-code)