### PR TITLE
test: add missing tests for Codex and Gemini runtime modules

### DIFF
--- a/crates/belt-infra/src/runtimes/codex.rs
+++ b/crates/belt-infra/src/runtimes/codex.rs
@@ -176,4 +176,150 @@ mod tests {
         let runtime = CodexRuntime::new(None);
         assert_eq!(runtime.name(), "codex");
     }
+
+    #[test]
+    fn new_with_default_model_stores_model() {
+        let runtime = CodexRuntime::new(Some("gpt-4o".to_string()));
+        // name() and capabilities() remain valid regardless of model
+        assert_eq!(runtime.name(), "codex");
+        assert_eq!(runtime.default_model.as_deref(), Some("gpt-4o"));
+    }
+
+    #[test]
+    fn new_with_no_default_model_is_none() {
+        let runtime = CodexRuntime::new(None);
+        assert!(runtime.default_model.is_none());
+    }
+
+    #[test]
+    fn parse_json_with_empty_result_field() {
+        let json = r#"{
+            "result": "",
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 5
+            }
+        }"#;
+        let (usage, _session_id, result) = parse_codex_json(json);
+        assert_eq!(result, "");
+        let usage = usage.unwrap();
+        assert_eq!(usage.input_tokens, 10);
+        assert_eq!(usage.output_tokens, 5);
+    }
+
+    #[test]
+    fn parse_json_missing_result_field_defaults_to_empty_string() {
+        // result field is absent — unwrap_or_default() should return ""
+        let json = r#"{
+            "usage": {
+                "input_tokens": 50,
+                "output_tokens": 30
+            },
+            "session_id": "sess-abc"
+        }"#;
+        let (usage, session_id, result) = parse_codex_json(json);
+        assert_eq!(result, "");
+        assert_eq!(session_id.as_deref(), Some("sess-abc"));
+        let usage = usage.unwrap();
+        assert_eq!(usage.input_tokens, 50);
+        assert_eq!(usage.output_tokens, 30);
+    }
+
+    #[test]
+    fn parse_json_with_zero_token_usage() {
+        let json = r#"{
+            "result": "empty response",
+            "usage": {
+                "input_tokens": 0,
+                "output_tokens": 0
+            }
+        }"#;
+        let (usage, _session_id, result) = parse_codex_json(json);
+        assert_eq!(result, "empty response");
+        let usage = usage.unwrap();
+        assert_eq!(usage.input_tokens, 0);
+        assert_eq!(usage.output_tokens, 0);
+        assert!(usage.cache_read_tokens.is_none());
+        assert!(usage.cache_write_tokens.is_none());
+    }
+
+    #[test]
+    fn parse_empty_string_returns_raw() {
+        let raw = "";
+        let (usage, session_id, result) = parse_codex_json(raw);
+        assert!(usage.is_none());
+        assert!(session_id.is_none());
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn parse_json_unknown_fields_are_ignored() {
+        // serde should ignore extra fields (no deny_unknown_fields)
+        let json = r#"{
+            "result": "output",
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "unknown_field": "ignored"
+            },
+            "extra_top_level": true
+        }"#;
+        let (usage, _session_id, result) = parse_codex_json(json);
+        assert_eq!(result, "output");
+        let usage = usage.unwrap();
+        assert_eq!(usage.input_tokens, 100);
+        assert_eq!(usage.output_tokens, 50);
+    }
+
+    #[test]
+    fn parse_json_with_large_token_counts() {
+        let json = r#"{
+            "result": "large output",
+            "usage": {
+                "input_tokens": 1000000,
+                "output_tokens": 999999
+            },
+            "session_id": "big-sess"
+        }"#;
+        let (usage, session_id, result) = parse_codex_json(json);
+        assert_eq!(result, "large output");
+        assert_eq!(session_id.as_deref(), Some("big-sess"));
+        let usage = usage.unwrap();
+        assert_eq!(usage.input_tokens, 1_000_000);
+        assert_eq!(usage.output_tokens, 999_999);
+        assert!(usage.cache_read_tokens.is_none());
+        assert!(usage.cache_write_tokens.is_none());
+    }
+
+    #[test]
+    fn parse_empty_json_object_returns_empty_result_no_usage() {
+        let json = r#"{}"#;
+        let (usage, session_id, result) = parse_codex_json(json);
+        // All fields are #[serde(default)] so parsing succeeds; result defaults to ""
+        assert!(usage.is_none());
+        assert!(session_id.is_none());
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn parse_whitespace_only_string_returns_raw() {
+        let raw = "   \n\t  ";
+        let (usage, session_id, result) = parse_codex_json(raw);
+        assert!(usage.is_none());
+        assert!(session_id.is_none());
+        assert_eq!(result, raw);
+    }
+
+    #[test]
+    fn capabilities_cache_tokens_are_none() {
+        // Codex does not expose cache tokens — verify via a parsed usage block
+        let json = r#"{
+            "result": "x",
+            "usage": { "input_tokens": 1, "output_tokens": 2 }
+        }"#;
+        let (usage, _, _) = parse_codex_json(json);
+        let usage = usage.unwrap();
+        assert!(usage.cache_read_tokens.is_none());
+        assert!(usage.cache_write_tokens.is_none());
+    }
 }

--- a/crates/belt-infra/src/runtimes/gemini.rs
+++ b/crates/belt-infra/src/runtimes/gemini.rs
@@ -188,4 +188,152 @@ mod tests {
         let runtime = GeminiRuntime::new(None);
         assert_eq!(runtime.name(), "gemini");
     }
+
+    #[test]
+    fn new_with_default_model_stores_model() {
+        let runtime = GeminiRuntime::new(Some("gemini-1.5-pro".to_string()));
+        assert_eq!(runtime.name(), "gemini");
+        assert_eq!(runtime.default_model.as_deref(), Some("gemini-1.5-pro"));
+    }
+
+    #[test]
+    fn new_with_no_default_model_is_none() {
+        let runtime = GeminiRuntime::new(None);
+        assert!(runtime.default_model.is_none());
+    }
+
+    #[test]
+    fn parse_json_with_empty_text_field() {
+        let json = r#"{
+            "text": "",
+            "usage_metadata": {
+                "prompt_token_count": 5,
+                "candidates_token_count": 0,
+                "cached_content_token_count": 0
+            }
+        }"#;
+        let (usage, result) = parse_gemini_json(json);
+        assert_eq!(result, "");
+        let usage = usage.unwrap();
+        assert_eq!(usage.input_tokens, 5);
+        assert_eq!(usage.output_tokens, 0);
+        assert_eq!(usage.cache_read_tokens, Some(0));
+    }
+
+    #[test]
+    fn parse_json_missing_text_field_defaults_to_empty_string() {
+        // text field is absent — unwrap_or_default() should return ""
+        let json = r#"{
+            "usage_metadata": {
+                "prompt_token_count": 20,
+                "candidates_token_count": 10,
+                "cached_content_token_count": 3
+            }
+        }"#;
+        let (usage, result) = parse_gemini_json(json);
+        assert_eq!(result, "");
+        let usage = usage.unwrap();
+        assert_eq!(usage.input_tokens, 20);
+        assert_eq!(usage.output_tokens, 10);
+        assert_eq!(usage.cache_read_tokens, Some(3));
+    }
+
+    #[test]
+    fn parse_json_with_zero_usage_metadata() {
+        let json = r#"{
+            "text": "zero tokens",
+            "usage_metadata": {
+                "prompt_token_count": 0,
+                "candidates_token_count": 0,
+                "cached_content_token_count": 0
+            }
+        }"#;
+        let (usage, result) = parse_gemini_json(json);
+        assert_eq!(result, "zero tokens");
+        let usage = usage.unwrap();
+        assert_eq!(usage.input_tokens, 0);
+        assert_eq!(usage.output_tokens, 0);
+        assert_eq!(usage.cache_read_tokens, Some(0));
+        assert!(usage.cache_write_tokens.is_none());
+    }
+
+    #[test]
+    fn parse_empty_string_returns_raw() {
+        let raw = "";
+        let (usage, result) = parse_gemini_json(raw);
+        assert!(usage.is_none());
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn parse_empty_json_object_returns_empty_result_no_usage() {
+        // All fields are #[serde(default)] so {} parses successfully
+        let json = r#"{}"#;
+        let (usage, result) = parse_gemini_json(json);
+        assert!(usage.is_none());
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn parse_json_unknown_fields_are_ignored() {
+        let json = r#"{
+            "text": "good output",
+            "usage_metadata": {
+                "prompt_token_count": 30,
+                "candidates_token_count": 15,
+                "cached_content_token_count": 2,
+                "totally_unknown": 99
+            },
+            "model_version": "gemini-1.5-flash-001"
+        }"#;
+        let (usage, result) = parse_gemini_json(json);
+        assert_eq!(result, "good output");
+        let usage = usage.unwrap();
+        assert_eq!(usage.input_tokens, 30);
+        assert_eq!(usage.output_tokens, 15);
+        assert_eq!(usage.cache_read_tokens, Some(2));
+    }
+
+    #[test]
+    fn parse_json_with_large_token_counts() {
+        let json = r#"{
+            "text": "big result",
+            "usage_metadata": {
+                "prompt_token_count": 2000000,
+                "candidates_token_count": 1500000,
+                "cached_content_token_count": 500000
+            }
+        }"#;
+        let (usage, result) = parse_gemini_json(json);
+        assert_eq!(result, "big result");
+        let usage = usage.unwrap();
+        assert_eq!(usage.input_tokens, 2_000_000);
+        assert_eq!(usage.output_tokens, 1_500_000);
+        assert_eq!(usage.cache_read_tokens, Some(500_000));
+        assert!(usage.cache_write_tokens.is_none());
+    }
+
+    #[test]
+    fn parse_whitespace_only_string_returns_raw() {
+        let raw = "   \n\t  ";
+        let (usage, result) = parse_gemini_json(raw);
+        assert!(usage.is_none());
+        assert_eq!(result, raw);
+    }
+
+    #[test]
+    fn capabilities_cache_write_tokens_are_always_none() {
+        // Gemini does not report cache write tokens
+        let json = r#"{
+            "text": "x",
+            "usage_metadata": {
+                "prompt_token_count": 1,
+                "candidates_token_count": 1,
+                "cached_content_token_count": 1
+            }
+        }"#;
+        let (usage, _) = parse_gemini_json(json);
+        let usage = usage.unwrap();
+        assert!(usage.cache_write_tokens.is_none());
+    }
 }


### PR DESCRIPTION
## Summary

Added 22 comprehensive test functions for Codex and Gemini runtime modules:

- **codex.rs**: 11 test functions covering constructor, parse_json edge cases, empty/whitespace input, zero tokens, large token counts, and cache token semantics
- **gemini.rs**: 11 test functions with same coverage as Codex for consistency

All tests pass and cover critical functionality for runtime modules.

## Changes

- crates/belt-infra/src/runtimes/codex.rs: Added 11 test functions (146 lines)
- crates/belt-infra/src/runtimes/gemini.rs: Added 11 test functions (148 lines)

## Test Coverage

- Constructor and initialization
- JSON parsing with edge cases
- Empty and whitespace input handling
- Zero and large token count scenarios
- Cache token semantics

Generated with Claude Code