### PR TITLE
feat(core): implement DependencyGuard for spec execution ordering

### DIFF
--- a/crates/belt-core/src/dependency.rs
+++ b/crates/belt-core/src/dependency.rs
@@ -1,0 +1,213 @@
+use crate::spec::{Spec, SpecStatus};
+
+/// Result of a dependency check for a single spec.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DependencyCheckResult {
+    /// All dependencies are satisfied (completed).
+    Satisfied,
+    /// One or more dependencies are not yet completed.
+    Blocked {
+        /// IDs of the specs that are still pending/incomplete.
+        pending_deps: Vec<String>,
+    },
+    /// No dependencies declared — always satisfies.
+    NoDependencies,
+}
+
+impl DependencyCheckResult {
+    /// Returns `true` if execution is allowed (satisfied or no dependencies).
+    pub fn is_ready(&self) -> bool {
+        matches!(
+            self,
+            DependencyCheckResult::Satisfied | DependencyCheckResult::NoDependencies
+        )
+    }
+}
+
+/// Trait for checking whether a spec's dependencies have been met.
+///
+/// The daemon calls `check_dependencies` before promoting an item
+/// from Pending to Ready. If any dependency spec is not yet Completed,
+/// the item stays in Pending.
+pub trait DependencyGuard {
+    /// Check whether all specs listed in `spec.depends_on` are completed.
+    ///
+    /// `resolve_spec` is a callback that looks up a spec by its ID.
+    /// This avoids coupling the guard to any particular storage backend.
+    fn check_dependencies<F>(&self, spec: &Spec, resolve_spec: F) -> DependencyCheckResult
+    where
+        F: Fn(&str) -> Option<Spec>;
+}
+
+/// Default implementation that blocks execution when any dependency
+/// spec has not reached [`SpecStatus::Completed`].
+#[derive(Debug, Default)]
+pub struct SpecDependencyGuard;
+
+impl DependencyGuard for SpecDependencyGuard {
+    fn check_dependencies<F>(&self, spec: &Spec, resolve_spec: F) -> DependencyCheckResult
+    where
+        F: Fn(&str) -> Option<Spec>,
+    {
+        let deps_str = match &spec.depends_on {
+            Some(s) if !s.trim().is_empty() => s,
+            _ => return DependencyCheckResult::NoDependencies,
+        };
+
+        let dep_ids: Vec<&str> = deps_str.split(',').map(|s| s.trim()).collect();
+
+        let pending_deps: Vec<String> = dep_ids
+            .into_iter()
+            .filter(|id| {
+                match resolve_spec(id) {
+                    Some(dep_spec) => dep_spec.status != SpecStatus::Completed,
+                    // If the dependency spec is not found, treat it as blocking
+                    // (safe default per HITL principle).
+                    None => true,
+                }
+            })
+            .map(|id| id.to_string())
+            .collect();
+
+        if pending_deps.is_empty() {
+            DependencyCheckResult::Satisfied
+        } else {
+            DependencyCheckResult::Blocked { pending_deps }
+        }
+    }
+}
+
+/// Parse a `depends_on` string into individual spec IDs.
+pub fn parse_depends_on(depends_on: &str) -> Vec<&str> {
+    depends_on
+        .split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spec::Spec;
+
+    fn make_spec(id: &str, status: SpecStatus, depends_on: Option<&str>) -> Spec {
+        let mut spec = Spec::new(
+            id.to_string(),
+            "ws-1".to_string(),
+            format!("Spec {id}"),
+            "content".to_string(),
+        );
+        spec.status = status;
+        spec.depends_on = depends_on.map(|s| s.to_string());
+        spec
+    }
+
+    #[test]
+    fn no_dependencies_is_ready() {
+        let guard = SpecDependencyGuard;
+        let spec = make_spec("s1", SpecStatus::Active, None);
+        let result = guard.check_dependencies(&spec, |_| None);
+        assert_eq!(result, DependencyCheckResult::NoDependencies);
+        assert!(result.is_ready());
+    }
+
+    #[test]
+    fn empty_depends_on_is_ready() {
+        let guard = SpecDependencyGuard;
+        let spec = make_spec("s1", SpecStatus::Active, Some(""));
+        let result = guard.check_dependencies(&spec, |_| None);
+        assert_eq!(result, DependencyCheckResult::NoDependencies);
+        assert!(result.is_ready());
+    }
+
+    #[test]
+    fn whitespace_only_depends_on_is_ready() {
+        let guard = SpecDependencyGuard;
+        let spec = make_spec("s1", SpecStatus::Active, Some("  "));
+        let result = guard.check_dependencies(&spec, |_| None);
+        assert_eq!(result, DependencyCheckResult::NoDependencies);
+    }
+
+    #[test]
+    fn all_deps_completed_is_satisfied() {
+        let guard = SpecDependencyGuard;
+        let spec = make_spec("s3", SpecStatus::Active, Some("s1,s2"));
+        let dep1 = make_spec("s1", SpecStatus::Completed, None);
+        let dep2 = make_spec("s2", SpecStatus::Completed, None);
+
+        let result = guard.check_dependencies(&spec, |id| match id {
+            "s1" => Some(dep1.clone()),
+            "s2" => Some(dep2.clone()),
+            _ => None,
+        });
+        assert_eq!(result, DependencyCheckResult::Satisfied);
+        assert!(result.is_ready());
+    }
+
+    #[test]
+    fn incomplete_dep_blocks() {
+        let guard = SpecDependencyGuard;
+        let spec = make_spec("s3", SpecStatus::Active, Some("s1,s2"));
+        let dep1 = make_spec("s1", SpecStatus::Completed, None);
+        let dep2 = make_spec("s2", SpecStatus::Active, None);
+
+        let result = guard.check_dependencies(&spec, |id| match id {
+            "s1" => Some(dep1.clone()),
+            "s2" => Some(dep2.clone()),
+            _ => None,
+        });
+        assert_eq!(
+            result,
+            DependencyCheckResult::Blocked {
+                pending_deps: vec!["s2".to_string()]
+            }
+        );
+        assert!(!result.is_ready());
+    }
+
+    #[test]
+    fn missing_dep_blocks_safe_default() {
+        let guard = SpecDependencyGuard;
+        let spec = make_spec("s2", SpecStatus::Active, Some("s1"));
+
+        let result = guard.check_dependencies(&spec, |_| None);
+        assert_eq!(
+            result,
+            DependencyCheckResult::Blocked {
+                pending_deps: vec!["s1".to_string()]
+            }
+        );
+        assert!(!result.is_ready());
+    }
+
+    #[test]
+    fn depends_on_with_whitespace_trimmed() {
+        let guard = SpecDependencyGuard;
+        let spec = make_spec("s2", SpecStatus::Active, Some(" s1 , s0 "));
+        let dep1 = make_spec("s1", SpecStatus::Completed, None);
+        let dep0 = make_spec("s0", SpecStatus::Completed, None);
+
+        let result = guard.check_dependencies(&spec, |id| match id {
+            "s1" => Some(dep1.clone()),
+            "s0" => Some(dep0.clone()),
+            _ => None,
+        });
+        assert_eq!(result, DependencyCheckResult::Satisfied);
+    }
+
+    #[test]
+    fn parse_depends_on_basic() {
+        assert_eq!(parse_depends_on("s1,s2,s3"), vec!["s1", "s2", "s3"]);
+    }
+
+    #[test]
+    fn parse_depends_on_with_whitespace() {
+        assert_eq!(parse_depends_on(" s1 , s2 "), vec!["s1", "s2"]);
+    }
+
+    #[test]
+    fn parse_depends_on_empty_entries_filtered() {
+        assert_eq!(parse_depends_on("s1,,s2,"), vec!["s1", "s2"]);
+    }
+}

--- a/crates/belt-core/src/lib.rs
+++ b/crates/belt-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod action;
 pub mod context;
+pub mod dependency;
 pub mod error;
 pub mod escalation;
 pub mod phase;

--- a/crates/belt-daemon/src/daemon.rs
+++ b/crates/belt-daemon/src/daemon.rs
@@ -7,6 +7,7 @@ use chrono::Utc;
 
 use belt_core::action::Action;
 use belt_core::context::HistoryEntry;
+use belt_core::dependency::{DependencyGuard, SpecDependencyGuard};
 use belt_core::error::BeltError;
 use belt_core::escalation::EscalationAction;
 use belt_core::phase::QueuePhase;
@@ -58,6 +59,8 @@ pub struct Daemon {
     shutdown_requested: bool,
     /// Evaluator 스크립트 실행을 위한 Belt home 디렉토리.
     belt_home: PathBuf,
+    /// Dependency guard for spec execution ordering.
+    dependency_guard: SpecDependencyGuard,
 }
 
 #[derive(Debug)]
@@ -121,6 +124,7 @@ impl Daemon {
             belt_home: PathBuf::from(
                 std::env::var("BELT_HOME").unwrap_or_else(|_| ".belt".to_string()),
             ),
+            dependency_guard: SpecDependencyGuard,
         }
     }
 
@@ -187,12 +191,32 @@ impl Daemon {
     pub fn advance(&mut self) -> usize {
         let mut advanced = 0;
 
-        // Pending -> Ready (uses safe transit)
-        for item in self.queue.iter_mut() {
-            if item.phase == QueuePhase::Pending
-                && state_machine::transit(QueuePhase::Pending, QueuePhase::Ready).is_ok()
-                && transit(item, QueuePhase::Ready).is_ok()
-            {
+        // Pending -> Ready (uses safe transit + dependency gate)
+        // Collect indices first to avoid borrow issues with self.
+        let pending_indices: Vec<usize> = self
+            .queue
+            .iter()
+            .enumerate()
+            .filter(|(_, item)| item.phase == QueuePhase::Pending)
+            .map(|(i, _)| i)
+            .collect();
+
+        for idx in pending_indices {
+            if state_machine::transit(QueuePhase::Pending, QueuePhase::Ready).is_err() {
+                continue;
+            }
+
+            // Dependency gate: check if the spec's depends_on specs are all completed.
+            if !self.check_dependency_gate(&self.queue[idx].source_id.clone()) {
+                tracing::debug!(
+                    "dependency gate blocked: {} (source={})",
+                    self.queue[idx].work_id,
+                    self.queue[idx].source_id
+                );
+                continue;
+            }
+
+            if transit(&mut self.queue[idx], QueuePhase::Ready).is_ok() {
                 advanced += 1;
             }
         }
@@ -265,6 +289,34 @@ impl Daemon {
         }
     }
 
+    /// Check whether a queue item's associated spec has all dependencies completed.
+    ///
+    /// Uses the database to resolve specs. If no database is configured or no
+    /// matching spec is found, the gate is open (returns `true`) to avoid
+    /// blocking items that are not spec-based.
+    fn check_dependency_gate(&self, source_id: &str) -> bool {
+        let db = match &self.db {
+            Some(db) => db,
+            None => return true,
+        };
+
+        // Try to find a spec whose ID matches the source_id.
+        let spec = match db.get_spec(source_id) {
+            Ok(spec) => spec,
+            Err(_) => return true, // No matching spec — gate open.
+        };
+
+        let result = self
+            .dependency_guard
+            .check_dependencies(&spec, |dep_id| db.get_spec(dep_id).ok());
+
+        if !result.is_ready() {
+            tracing::trace!("spec {} blocked by dependencies: {:?}", spec.id, result);
+        }
+
+        result.is_ready()
+    }
+
     // ---------------------------------------------------------------
     // Phase 3: Execute running items (parallel)
     // ---------------------------------------------------------------
@@ -324,7 +376,6 @@ impl Daemon {
 
         outcomes
     }
-
 
     /// 단일 아이템의 handler를 실행하는 순수 async 함수.
     /// `&mut self` 의존 없이 `tokio::spawn`으로 실행 가능하다.
@@ -941,19 +992,18 @@ impl Daemon {
 
         // handler 성공 → Completed 전이 후 force_trigger("evaluate") (D-10).
         // force_trigger는 cron의 last_run_at을 리셋하여 다음 tick에서 즉시 실행.
-        if has_completed
-            && let Some(ref mut engine) = self.cron_engine
-        {
+        if has_completed && let Some(ref mut engine) = self.cron_engine {
             engine.force_trigger("evaluate");
             tracing::debug!("force_trigger(evaluate) after handler completion");
         }
-
 
         // Evaluator로 Completed 아이템 평가 (Done vs HITL).
         self.evaluate_completed().await;
 
         // Cron jobs: HITL timeout, daily report, log cleanup, evaluate 등.
-        if let Some(ref mut engine) = self.cron_engine { engine.tick(); }
+        if let Some(ref mut engine) = self.cron_engine {
+            engine.tick();
+        }
 
         Ok(())
     }
@@ -2235,7 +2285,11 @@ sources:
 
         // Pending → Hitl is not a valid transition.
         daemon.push_item(test_item("s1", "analyze"));
-        let result = daemon.mark_hitl("s1:analyze", HitlReason::ManualEscalation, Some("reason".into()));
+        let result = daemon.mark_hitl(
+            "s1:analyze",
+            HitlReason::ManualEscalation,
+            Some("reason".into()),
+        );
         assert!(result.is_err());
         assert_eq!(
             daemon.get_item("s1:analyze").unwrap().phase,


### PR DESCRIPTION
Closes #106

## Summary
- Add DependencyGuard trait and SpecDependencyGuard implementation
- Parse depends_on field, check spec completion status
- Integrate gate into daemon Pending→Ready transition
- 7 unit tests for dependency checking

## Test plan
- [ ] cargo test -p belt-core -p belt-daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)