### PR TITLE
feat(cli): auto-create GitHub issue on belt spec add

### DIFF
--- a/crates/belt-cli/src/agent.rs
+++ b/crates/belt-cli/src/agent.rs
@@ -196,7 +196,11 @@ mod tests {
         assert_eq!(actions.len(), 1);
         assert!(actions[0].is_prompt());
         match &actions[0] {
-            Action::Prompt { text, runtime, model } => {
+            Action::Prompt {
+                text,
+                runtime,
+                model,
+            } => {
                 assert_eq!(text, "do something");
                 assert!(runtime.is_none());
                 assert!(model.is_none());

--- a/crates/belt-cli/src/main.rs
+++ b/crates/belt-cli/src/main.rs
@@ -916,6 +916,30 @@ async fn main() -> anyhow::Result<()> {
                     spec.depends_on = depends_on;
                     db.insert_spec(&spec)?;
                     println!("spec created: {id}");
+
+                    // Auto-create GitHub issue with autopilot:ready label.
+                    let mut gh_cmd = std::process::Command::new("gh");
+                    gh_cmd.args(["issue", "create"]);
+                    gh_cmd.args(["--title", &spec.name]);
+                    gh_cmd.args(["--body", &spec.content]);
+                    gh_cmd.args(["--label", "autopilot:ready"]);
+                    match gh_cmd.output() {
+                        Ok(output) => {
+                            if output.status.success() {
+                                let url = String::from_utf8_lossy(&output.stdout);
+                                println!("GitHub issue created: {}", url.trim());
+                            } else {
+                                let stderr = String::from_utf8_lossy(&output.stderr);
+                                eprintln!(
+                                    "warning: failed to create GitHub issue: {}",
+                                    stderr.trim()
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("warning: could not run `gh` CLI: {e}");
+                        }
+                    }
                 }
                 SpecCommands::List {
                     workspace,


### PR DESCRIPTION
Closes #114

## Summary
- After DB insert, invoke gh issue create with spec name/content
- Attach autopilot:ready label automatically
- Best-effort: failure logged as warning, spec persists regardless

## Test plan
- [ ] cargo check -p belt-cli

🤖 Generated with [Claude Code](https://claude.com/claude-code)