### PR TITLE
fix(test): resolve belt-cli test compile errors

### DIFF
--- a/crates/belt-cli/src/agent.rs
+++ b/crates/belt-cli/src/agent.rs
@@ -127,6 +127,7 @@ mod tests {
             concurrency: 1,
             sources: HashMap::new(),
             runtime: RuntimeConfig::default(),
+            claw_config: None,
         }
     }
 
@@ -184,6 +185,7 @@ mod tests {
             concurrency: 2,
             sources,
             runtime: RuntimeConfig::default(),
+            claw_config: None,
         }
     }
 

--- a/crates/belt-cli/src/main.rs
+++ b/crates/belt-cli/src/main.rs
@@ -884,9 +884,7 @@ async fn main() -> anyhow::Result<()> {
 
             if let Some(ref field_path) = field {
                 let value = serde_json::to_value(&ctx)?;
-                let extracted = field_path
-                    .split('.')
-                    .try_fold(&value, |v, key| v.get(key));
+                let extracted = field_path.split('.').try_fold(&value, |v, key| v.get(key));
                 match extracted {
                     Some(v) if v.is_string() => {
                         println!("{}", v.as_str().unwrap());

--- a/crates/belt-cli/src/status.rs
+++ b/crates/belt-cli/src/status.rs
@@ -55,6 +55,14 @@ pub struct SpecStatus {
     pub phase_counts: Vec<PhaseCount>,
 }
 
+/// Lightweight status output for JSON serialization.
+#[derive(Debug, Serialize)]
+pub struct StatusOutput<'a> {
+    pub status: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_stats: Option<RuntimeStats>,
+}
+
 /// Display system status in the requested format.
 ///
 /// Opens the default Belt database automatically.


### PR DESCRIPTION
Closes #122

## Summary
- Add claw_config: None to WorkspaceConfig test initializers in agent.rs
- Add missing StatusOutput struct definition in status.rs
- 65 tests now passing

## Test plan
- [x] cargo test -p belt-cli (65 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)