### PR TITLE
test: fix missing #[test] attr and add phase_color tests

### DIFF
--- a/crates/belt-cli/src/dashboard.rs
+++ b/crates/belt-cli/src/dashboard.rs
@@ -468,4 +468,53 @@ mod tests {
         assert_eq!(models[0].model, "large-model");
         assert_eq!(models[1].model, "small-model");
     }
+
+    // ---- phase_color ----
+
+    #[test]
+    fn phase_color_pending() {
+        assert_eq!(phase_color("pending"), Color::Gray);
+    }
+
+    #[test]
+    fn phase_color_ready() {
+        assert_eq!(phase_color("ready"), Color::Blue);
+    }
+
+    #[test]
+    fn phase_color_running() {
+        assert_eq!(phase_color("running"), Color::Green);
+    }
+
+    #[test]
+    fn phase_color_completed() {
+        assert_eq!(phase_color("completed"), Color::Cyan);
+    }
+
+    #[test]
+    fn phase_color_done() {
+        assert_eq!(phase_color("done"), Color::White);
+    }
+
+    #[test]
+    fn phase_color_hitl() {
+        assert_eq!(phase_color("hitl"), Color::Yellow);
+    }
+
+    #[test]
+    fn phase_color_failed() {
+        assert_eq!(phase_color("failed"), Color::Red);
+    }
+
+    #[test]
+    fn phase_color_skipped() {
+        assert_eq!(phase_color("skipped"), Color::DarkGray);
+    }
+
+    #[test]
+    fn phase_color_unknown_returns_white() {
+        assert_eq!(phase_color("unknown"), Color::White);
+        assert_eq!(phase_color(""), Color::White);
+        assert_eq!(phase_color("PENDING"), Color::White);
+    }
 }

--- a/crates/belt-core/src/queue.rs
+++ b/crates/belt-core/src/queue.rs
@@ -357,6 +357,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn worktree_preserved_default_false() {
         let item = test_item("s1", "analyze");
         assert!(!item.worktree_preserved);


### PR DESCRIPTION
## Summary

- **BUG FIX**: `crates/belt-core/src/queue.rs` - Added missing `#[test]` attribute to `worktree_preserved_default_false()` test which was never being executed by the test runner
- **NEW TESTS**: `crates/belt-cli/src/dashboard.rs` - Added 9 comprehensive tests for `phase_color()` function covering all 8 phases + wildcard fallback case

## Test Results

All 167 tests passed without failures.

## Changes

This QA boost improves test coverage and fixes a previously-ignored test that was not running due to a missing attribute.