### PR TITLE
feat: [gap] R-049: Implement spec completion flow (Completing state)

### DIFF
--- a/crates/belt-cli/src/main.rs
+++ b/crates/belt-cli/src/main.rs
@@ -1091,17 +1091,36 @@ async fn main() -> anyhow::Result<()> {
                 }
                 SpecCommands::Complete { id } => {
                     let spec = db.get_spec(&id)?;
-                    if !spec
-                        .status
-                        .can_transition_to(&belt_core::spec::SpecStatus::Completed)
-                    {
+                    // Determine the target status based on current state:
+                    // Active -> Completing (enter completion flow)
+                    // Completing -> Completed (HITL final approval)
+                    let target = if spec.status == belt_core::spec::SpecStatus::Active {
+                        belt_core::spec::SpecStatus::Completing
+                    } else if spec.status == belt_core::spec::SpecStatus::Completing {
+                        belt_core::spec::SpecStatus::Completed
+                    } else {
                         anyhow::bail!(
-                            "cannot complete spec in status '{}': only active specs can be completed",
+                            "cannot complete spec in status '{}': only active or completing specs can advance toward completion",
                             spec.status
                         );
+                    };
+                    if !spec.status.can_transition_to(&target) {
+                        anyhow::bail!(
+                            "invalid transition: {} -> {}",
+                            spec.status,
+                            target
+                        );
                     }
-                    db.update_spec_status(&id, belt_core::spec::SpecStatus::Completed)?;
-                    println!("spec completed: {id}");
+                    db.update_spec_status(&id, target)?;
+                    match target {
+                        belt_core::spec::SpecStatus::Completing => {
+                            println!("spec entering completion flow: {id}");
+                        }
+                        belt_core::spec::SpecStatus::Completed => {
+                            println!("spec completed: {id}");
+                        }
+                        _ => unreachable!(),
+                    }
                 }
                 SpecCommands::Remove { id } => {
                     db.remove_spec(&id)?;

--- a/crates/belt-core/src/spec.rs
+++ b/crates/belt-core/src/spec.rs
@@ -5,7 +5,9 @@ use serde::{Deserialize, Serialize};
 /// Spec lifecycle status.
 ///
 /// ```text
-/// Draft -> Active -> [Paused <-> Active] -> Completed
+/// Draft -> Active -> [Paused <-> Active] -> Completing -> Completed
+///                                               |
+///                                               └-> Active (gap found)
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -13,6 +15,9 @@ pub enum SpecStatus {
     Draft,
     Active,
     Paused,
+    /// Gap-detection found no gaps and all linked issues are Done.
+    /// Awaiting test execution and HITL final confirmation.
+    Completing,
     Completed,
 }
 
@@ -23,6 +28,7 @@ impl SpecStatus {
             SpecStatus::Draft => "draft",
             SpecStatus::Active => "active",
             SpecStatus::Paused => "paused",
+            SpecStatus::Completing => "completing",
             SpecStatus::Completed => "completed",
         }
     }
@@ -46,6 +52,7 @@ impl std::str::FromStr for SpecStatus {
             "draft" => Ok(SpecStatus::Draft),
             "active" => Ok(SpecStatus::Active),
             "paused" => Ok(SpecStatus::Paused),
+            "completing" => Ok(SpecStatus::Completing),
             "completed" => Ok(SpecStatus::Completed),
             _ => Err(format!("invalid spec status: {s}")),
         }
@@ -63,13 +70,20 @@ impl fmt::Display for SpecStatus {
 /// Valid transitions:
 /// - Draft -> Active
 /// - Active -> Paused
-/// - Active -> Completed
+/// - Active -> Completing (gap-detection finds no gaps, all linked issues Done)
 /// - Paused -> Active
+/// - Completing -> Completed (HITL final approval)
+/// - Completing -> Active (gap found during re-check or test failure)
 pub fn is_valid_spec_transition(from: SpecStatus, to: SpecStatus) -> bool {
     use SpecStatus::*;
     matches!(
         (from, to),
-        (Draft, Active) | (Active, Paused) | (Active, Completed) | (Paused, Active)
+        (Draft, Active)
+            | (Active, Paused)
+            | (Active, Completing)
+            | (Paused, Active)
+            | (Completing, Completed)
+            | (Completing, Active)
     )
 }
 
@@ -175,23 +189,31 @@ mod tests {
     fn valid_transitions() {
         assert!(transit_spec(Draft, Active).is_ok());
         assert!(transit_spec(Active, Paused).is_ok());
-        assert!(transit_spec(Active, Completed).is_ok());
+        assert!(transit_spec(Active, Completing).is_ok());
         assert!(transit_spec(Paused, Active).is_ok());
+        assert!(transit_spec(Completing, Completed).is_ok());
+        assert!(transit_spec(Completing, Active).is_ok());
     }
 
     #[test]
     fn invalid_transitions() {
         assert!(transit_spec(Draft, Paused).is_err());
         assert!(transit_spec(Draft, Completed).is_err());
+        assert!(transit_spec(Draft, Completing).is_err());
         assert!(transit_spec(Paused, Completed).is_err());
+        assert!(transit_spec(Paused, Completing).is_err());
         assert!(transit_spec(Paused, Draft).is_err());
+        assert!(transit_spec(Active, Completed).is_err());
         assert!(transit_spec(Completed, Active).is_err());
         assert!(transit_spec(Completed, Draft).is_err());
+        assert!(transit_spec(Completed, Completing).is_err());
+        assert!(transit_spec(Completing, Draft).is_err());
+        assert!(transit_spec(Completing, Paused).is_err());
     }
 
     #[test]
     fn same_status_rejected() {
-        let statuses = [Draft, Active, Paused, Completed];
+        let statuses = [Draft, Active, Paused, Completing, Completed];
         for s in statuses {
             assert_eq!(
                 transit_spec(s, s).unwrap_err(),
@@ -202,18 +224,18 @@ mod tests {
 
     #[test]
     fn exhaustive_transition_count() {
-        let statuses = [Draft, Active, Paused, Completed];
+        let statuses = [Draft, Active, Paused, Completing, Completed];
         let valid_count = statuses
             .iter()
             .flat_map(|&from| statuses.iter().map(move |&to| (from, to)))
             .filter(|&(from, to)| is_valid_spec_transition(from, to))
             .count();
-        assert_eq!(valid_count, 4);
+        assert_eq!(valid_count, 6);
     }
 
     #[test]
     fn status_roundtrip() {
-        let statuses = [Draft, Active, Paused, Completed];
+        let statuses = [Draft, Active, Paused, Completing, Completed];
         for s in statuses {
             let str_val = s.to_string();
             let parsed: SpecStatus = str_val.parse().unwrap();
@@ -236,6 +258,7 @@ mod tests {
         assert!(!Draft.is_terminal());
         assert!(!Active.is_terminal());
         assert!(!Paused.is_terminal());
+        assert!(!Completing.is_terminal());
     }
 
     #[test]
@@ -268,8 +291,12 @@ mod tests {
         let prev = spec.transition_to(Active).unwrap();
         assert_eq!(prev, Paused);
 
-        let prev = spec.transition_to(Completed).unwrap();
+        let prev = spec.transition_to(Completing).unwrap();
         assert_eq!(prev, Active);
+        assert_eq!(spec.status, Completing);
+
+        let prev = spec.transition_to(Completed).unwrap();
+        assert_eq!(prev, Completing);
         assert_eq!(spec.status, Completed);
     }
 

--- a/crates/belt-daemon/src/cron.rs
+++ b/crates/belt-daemon/src/cron.rs
@@ -516,10 +516,13 @@ impl CronHandler for GapDetectionJob {
 
         // Step 3: For each spec, extract keywords and check coverage.
         let mut gaps: Vec<DetectedGap> = Vec::new();
+        let mut covered_spec_ids: Vec<String> = Vec::new();
 
         for spec in &active_specs {
             let keywords = extract_keywords(&spec.content);
             if keywords.is_empty() {
+                // Specs with no extractable keywords are considered covered.
+                covered_spec_ids.push(spec.id.clone());
                 continue;
             }
 
@@ -548,6 +551,8 @@ impl CronHandler for GapDetectionJob {
                     spec_name: spec.name.clone(),
                     missing_keywords: missing,
                 });
+            } else {
+                covered_spec_ids.push(spec.id.clone());
             }
         }
 
@@ -605,9 +610,33 @@ impl CronHandler for GapDetectionJob {
             }
         }
 
+        // Step 5: Transition fully-covered specs to Completing.
+        // Per spec lifecycle, Active -> Completing when gap-detection finds
+        // no gaps. The HITL final confirmation flow will then advance to Completed.
+        let mut completing_count = 0usize;
+        for spec_id in &covered_spec_ids {
+            if let Err(e) =
+                self.db
+                    .update_spec_status(spec_id, belt_core::spec::SpecStatus::Completing)
+            {
+                tracing::warn!(
+                    spec_id = %spec_id,
+                    error = %e,
+                    "GapDetectionJob: failed to transition spec to Completing"
+                );
+            } else {
+                tracing::info!(
+                    spec_id = %spec_id,
+                    "GapDetectionJob: spec transitioned to Completing (no gaps found)"
+                );
+                completing_count += 1;
+            }
+        }
+
         tracing::info!(
             total_specs = active_specs.len(),
             gaps_found = gaps.len(),
+            completing = completing_count,
             "GapDetectionJob: completed gap detection scan"
         );
         Ok(())


### PR DESCRIPTION
## Summary

Implements the Completing state in the spec lifecycle as per requirement R-049.

Closes #130

## Changes

- Add Completing state handling in belt-core spec module
- Implement cron job for Completing state transitions in belt-daemon
- Update belt-cli main command to support the new Completing state workflow

## Test plan

- Run `cargo test` to verify all tests pass
- Run `cargo clippy -- -D warnings` to ensure code quality