### PR TITLE
feat: [gap] R-052: Implement per-workspace Claw directory creation

### DIFF
--- a/crates/belt-cli/src/main.rs
+++ b/crates/belt-cli/src/main.rs
@@ -717,9 +717,8 @@ async fn cmd_queue_retry_script(work_id: &str, timeout: Option<u64>) -> anyhow::
 
     // Load workspace config to find on_done scripts for this item's state.
     let (_, config_path, _) = db.get_workspace(&item.workspace_id)?;
-    let config = belt_infra::workspace_loader::load_workspace_config(std::path::Path::new(
-        &config_path,
-    ))?;
+    let config =
+        belt_infra::workspace_loader::load_workspace_config(std::path::Path::new(&config_path))?;
 
     // Find the state config containing on_done scripts.
     let state_config = config
@@ -735,21 +734,26 @@ async fn cmd_queue_retry_script(work_id: &str, timeout: Option<u64>) -> anyhow::
         })?;
 
     if state_config.on_done.is_empty() {
-        println!("No on_done scripts configured for state '{}'. Transitioning to done.", item.state);
+        println!(
+            "No on_done scripts configured for state '{}'. Transitioning to done.",
+            item.state
+        );
         db.update_phase(work_id, QueuePhase::Done)?;
         println!("Item '{work_id}' transitioned from failed to done.");
         return Ok(());
     }
 
-    let on_done: Vec<belt_core::action::Action> =
-        state_config.on_done.iter().map(belt_core::action::Action::from).collect();
+    let on_done: Vec<belt_core::action::Action> = state_config
+        .on_done
+        .iter()
+        .map(belt_core::action::Action::from)
+        .collect();
 
     // Set up execution environment.
     let belt_home = belt_home()?;
     let worktree_base = belt_home.join("worktrees");
     let repo_path = std::path::PathBuf::from(".");
-    let worktree_mgr =
-        belt_infra::worktree::GitWorktreeManager::new(worktree_base, repo_path);
+    let worktree_mgr = belt_infra::worktree::GitWorktreeManager::new(worktree_base, repo_path);
 
     let worktree_path = worktree_mgr.create_or_reuse(work_id)?;
     let env = belt_daemon::executor::ActionEnv::new(work_id, &worktree_path);
@@ -779,7 +783,9 @@ async fn cmd_queue_retry_script(work_id: &str, timeout: Option<u64>) -> anyhow::
     match result {
         Some(r) if r.success() => {
             db.update_phase(work_id, QueuePhase::Done)?;
-            println!("on_done scripts succeeded. Item '{work_id}' transitioned from failed to done.");
+            println!(
+                "on_done scripts succeeded. Item '{work_id}' transitioned from failed to done."
+            );
         }
         Some(r) => {
             println!(
@@ -852,11 +858,7 @@ fn cmd_cron_add(
 }
 
 /// `belt cron update` -- update schedule and/or script of an existing cron job.
-fn cmd_cron_update(
-    name: &str,
-    schedule: Option<&str>,
-    script: Option<&str>,
-) -> anyhow::Result<()> {
+fn cmd_cron_update(name: &str, schedule: Option<&str>, script: Option<&str>) -> anyhow::Result<()> {
     if schedule.is_none() && script.is_none() {
         anyhow::bail!("at least one of --schedule or --script must be provided");
     }
@@ -1106,9 +1108,10 @@ async fn main() -> anyhow::Result<()> {
             match command {
                 WorkspaceCommands::Add { config } => {
                     let config_path = std::path::Path::new(&config);
-                    let result = belt_infra::onboarding::onboard_workspace(&db, config_path)?;
+                    let result =
+                        belt_infra::onboarding::onboard_workspace(&db, config_path, &belt_home)?;
 
-                    // Initialize claw workspace automatically
+                    // Initialize global claw workspace automatically
                     let claw_ws = claw::ClawWorkspace::init(&belt_home)?;
                     tracing::info!(path = %claw_ws.path.display(), "claw workspace initialized");
 
@@ -1126,6 +1129,7 @@ async fn main() -> anyhow::Result<()> {
                     println!("  Config: {}", result.config_path);
                     println!("  Sources: {}", result.source_count);
                     println!("  Cron jobs seeded: {}", result.cron_jobs_seeded);
+                    println!("  Claw dir: {}", result.claw_dir.display());
                 }
                 WorkspaceCommands::List => {
                     let workspaces = db.list_workspaces()?;
@@ -1169,7 +1173,9 @@ async fn main() -> anyhow::Result<()> {
                         println!("Workspace '{}' updated.", name);
                         println!("  Config: {}", abs_path);
                     } else {
-                        println!("No update options provided. Use --config to update the config path.");
+                        println!(
+                            "No update options provided. Use --config to update the config path."
+                        );
                     }
                 }
                 WorkspaceCommands::Remove { name, force } => {
@@ -1587,11 +1593,7 @@ async fn main() -> anyhow::Result<()> {
                         );
                     };
                     if !spec.status.can_transition_to(&target) {
-                        anyhow::bail!(
-                            "invalid transition: {} -> {}",
-                            spec.status,
-                            target
-                        );
+                        anyhow::bail!("invalid transition: {} -> {}", spec.status, target);
                     }
                     db.update_spec_status(&id, target)?;
                     match target {

--- a/crates/belt-daemon/src/cron.rs
+++ b/crates/belt-daemon/src/cron.rs
@@ -638,9 +638,9 @@ impl CronHandler for GapDetectionJob {
         // no gaps. The HITL final confirmation flow will then advance to Completed.
         let mut completing_count = 0usize;
         for spec_id in &covered_spec_ids {
-            if let Err(e) =
-                self.db
-                    .update_spec_status(spec_id, belt_core::spec::SpecStatus::Completing)
+            if let Err(e) = self
+                .db
+                .update_spec_status(spec_id, belt_core::spec::SpecStatus::Completing)
             {
                 tracing::warn!(
                     spec_id = %spec_id,

--- a/crates/belt-infra/src/db.rs
+++ b/crates/belt-infra/src/db.rs
@@ -1867,8 +1867,13 @@ mod tests {
     #[test]
     fn cron_job_crud() {
         let db = test_db();
-        db.add_cron_job("sync-issues", "*/5 * * * *", "/usr/local/bin/sync.sh", Some("ws1"))
-            .unwrap();
+        db.add_cron_job(
+            "sync-issues",
+            "*/5 * * * *",
+            "/usr/local/bin/sync.sh",
+            Some("ws1"),
+        )
+        .unwrap();
 
         let jobs = db.list_cron_jobs().unwrap();
         assert_eq!(jobs.len(), 1);

--- a/crates/belt-infra/src/onboarding.rs
+++ b/crates/belt-infra/src/onboarding.rs
@@ -4,8 +4,9 @@
 //! 1. Parse workspace.yml
 //! 2. Save workspace to DB
 //! 3. Seed per-workspace cron jobs (CR-13)
+//! 4. Create per-workspace Claw directory (R-052)
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use belt_core::workspace::WorkspaceConfig;
 
@@ -25,6 +26,8 @@ pub struct OnboardingResult {
     pub cron_jobs_seeded: usize,
     /// Whether the workspace was newly created (vs. updated).
     pub created: bool,
+    /// Path to the per-workspace Claw directory.
+    pub claw_dir: PathBuf,
 }
 
 /// Per-workspace cron seed definitions (CR-13).
@@ -43,11 +46,18 @@ const WORKSPACE_CRON_SEEDS: &[(&str, &str)] = &[
 /// 1. Load and validate the workspace config from `config_path`.
 /// 2. Register (or update) the workspace in the database.
 /// 3. Seed per-workspace cron jobs.
+/// 4. Create per-workspace Claw directory structure.
+///
+/// `belt_home` is the root Belt data directory (typically `~/.belt`).
 ///
 /// # Errors
 /// Returns an error if the config file cannot be read/parsed, or if DB
 /// operations fail.
-pub fn onboard_workspace(db: &Database, config_path: &Path) -> anyhow::Result<OnboardingResult> {
+pub fn onboard_workspace(
+    db: &Database,
+    config_path: &Path,
+    belt_home: &Path,
+) -> anyhow::Result<OnboardingResult> {
     // Step 1: Parse workspace.yml
     let config: WorkspaceConfig = workspace_loader::load_workspace_config(config_path)?;
 
@@ -74,13 +84,68 @@ pub fn onboard_workspace(db: &Database, config_path: &Path) -> anyhow::Result<On
     // Step 3: Seed per-workspace cron jobs (CR-13)
     let cron_jobs_seeded = seed_workspace_cron_jobs(db, &config.name)?;
 
+    // Step 4: Create per-workspace Claw directory (R-052)
+    let claw_dir = init_workspace_claw_dir(belt_home, &config.name)?;
+
     Ok(OnboardingResult {
         workspace_name: config.name,
         config_path: abs_path,
         source_count: config.sources.len(),
         cron_jobs_seeded,
         created,
+        claw_dir,
     })
+}
+
+/// Default content for the per-workspace Claw `config.yaml`.
+fn default_claw_config_yaml(workspace_name: &str) -> String {
+    format!(
+        r#"# Claw configuration for workspace: {workspace_name}
+#
+# This file is auto-generated during workspace onboarding.
+# Customize per-workspace Claw behavior here.
+
+workspace: {workspace_name}
+auto_approve: false
+"#
+    )
+}
+
+/// Create the per-workspace Claw directory structure (R-052).
+///
+/// Produces the following layout under `belt_home`:
+/// ```text
+/// {belt_home}/workspaces/<workspace-name>/
+///   └── claw/
+///       ├── system/
+///       ├── session/
+///       └── config.yaml
+/// ```
+///
+/// The function is idempotent: existing directories and files are preserved.
+///
+/// Returns the path to the workspace's `claw/` directory.
+pub fn init_workspace_claw_dir(belt_home: &Path, workspace_name: &str) -> anyhow::Result<PathBuf> {
+    let ws_dir = belt_home.join("workspaces").join(workspace_name);
+    let claw_dir = ws_dir.join("claw");
+    let system_dir = claw_dir.join("system");
+    let session_dir = claw_dir.join("session");
+
+    std::fs::create_dir_all(&system_dir)?;
+    std::fs::create_dir_all(&session_dir)?;
+
+    let config_path = claw_dir.join("config.yaml");
+    if !config_path.exists() {
+        std::fs::write(&config_path, default_claw_config_yaml(workspace_name))?;
+    }
+
+    tracing::info!(
+        workspace = %workspace_name,
+        path = %claw_dir.display(),
+        "per-workspace claw directory initialized"
+    );
+
+    Ok(claw_dir)
 }
 
 /// Seed built-in cron jobs scoped to a workspace.
@@ -126,6 +191,11 @@ mod tests {
         tmp
     }
 
+    /// Create a temporary directory to serve as `belt_home` for tests.
+    fn test_belt_home() -> tempfile::TempDir {
+        tempfile::tempdir().expect("should create temp dir")
+    }
+
     const VALID_YAML: &str = r#"
 name: test-project
 concurrency: 2
@@ -141,8 +211,9 @@ sources:
     fn onboard_creates_workspace_and_cron_jobs() {
         let db = test_db();
         let tmp = write_workspace_yaml(VALID_YAML);
+        let belt_home = test_belt_home();
 
-        let result = onboard_workspace(&db, tmp.path()).unwrap();
+        let result = onboard_workspace(&db, tmp.path(), belt_home.path()).unwrap();
         assert_eq!(result.workspace_name, "test-project");
         assert_eq!(result.source_count, 2);
         assert_eq!(result.cron_jobs_seeded, 4);
@@ -172,14 +243,15 @@ sources:
     fn onboard_updates_existing_workspace() {
         let db = test_db();
         let tmp = write_workspace_yaml(VALID_YAML);
+        let belt_home = test_belt_home();
 
         // First onboard
-        let result1 = onboard_workspace(&db, tmp.path()).unwrap();
+        let result1 = onboard_workspace(&db, tmp.path(), belt_home.path()).unwrap();
         assert!(result1.created);
         assert_eq!(result1.cron_jobs_seeded, 4);
 
         // Second onboard should update, not create
-        let result2 = onboard_workspace(&db, tmp.path()).unwrap();
+        let result2 = onboard_workspace(&db, tmp.path(), belt_home.path()).unwrap();
         assert!(!result2.created);
         assert_eq!(result2.cron_jobs_seeded, 0); // Already exist
 
@@ -191,13 +263,19 @@ sources:
     #[test]
     fn onboard_invalid_config_errors() {
         let db = test_db();
-        let result = onboard_workspace(&db, Path::new("/nonexistent/workspace.yml"));
+        let belt_home = test_belt_home();
+        let result = onboard_workspace(
+            &db,
+            Path::new("/nonexistent/workspace.yml"),
+            belt_home.path(),
+        );
         assert!(result.is_err());
     }
 
     #[test]
     fn cron_seed_names_are_workspace_scoped() {
         let db = test_db();
+        let belt_home = test_belt_home();
         let yaml_a = r#"
 name: project-a
 sources:
@@ -213,8 +291,8 @@ sources:
         let tmp_a = write_workspace_yaml(yaml_a);
         let tmp_b = write_workspace_yaml(yaml_b);
 
-        onboard_workspace(&db, tmp_a.path()).unwrap();
-        onboard_workspace(&db, tmp_b.path()).unwrap();
+        onboard_workspace(&db, tmp_a.path(), belt_home.path()).unwrap();
+        onboard_workspace(&db, tmp_b.path(), belt_home.path()).unwrap();
 
         let jobs = db.list_cron_jobs().unwrap();
         assert_eq!(jobs.len(), 8); // 4 per workspace
@@ -228,10 +306,11 @@ sources:
     fn onboard_invalid_yaml_content_errors() {
         // File exists but contains invalid YAML — distinct from missing file.
         let db = test_db();
+        let belt_home = test_belt_home();
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         std::io::Write::write_all(&mut tmp, b"not: [valid: yaml: {{").unwrap();
 
-        let result = onboard_workspace(&db, tmp.path());
+        let result = onboard_workspace(&db, tmp.path(), belt_home.path());
         assert!(result.is_err());
         // No workspace or cron jobs should have been created.
         assert_eq!(db.list_cron_jobs().unwrap().len(), 0);
@@ -240,6 +319,7 @@ sources:
     #[test]
     fn onboard_yaml_missing_name_field_errors() {
         let db = test_db();
+        let belt_home = test_belt_home();
         let yaml = r#"
 concurrency: 2
 sources:
@@ -247,13 +327,14 @@ sources:
     url: https://github.com/org/repo
 "#;
         let tmp = write_workspace_yaml(yaml);
-        let result = onboard_workspace(&db, tmp.path());
+        let result = onboard_workspace(&db, tmp.path(), belt_home.path());
         assert!(result.is_err());
     }
 
     #[test]
     fn onboard_source_count_reflects_config() {
         let db = test_db();
+        let belt_home = test_belt_home();
         let yaml = r#"
 name: three-source-project
 sources:
@@ -265,16 +346,17 @@ sources:
     url: https://jira.example.com
 "#;
         let tmp = write_workspace_yaml(yaml);
-        let result = onboard_workspace(&db, tmp.path()).unwrap();
+        let result = onboard_workspace(&db, tmp.path(), belt_home.path()).unwrap();
         assert_eq!(result.source_count, 3);
     }
 
     #[test]
     fn onboard_zero_sources_succeeds() {
         let db = test_db();
+        let belt_home = test_belt_home();
         let yaml = "name: no-sources\nsources: {}\n";
         let tmp = write_workspace_yaml(yaml);
-        let result = onboard_workspace(&db, tmp.path()).unwrap();
+        let result = onboard_workspace(&db, tmp.path(), belt_home.path()).unwrap();
         assert_eq!(result.workspace_name, "no-sources");
         assert_eq!(result.source_count, 0);
         assert!(result.created);
@@ -285,16 +367,18 @@ sources:
     #[test]
     fn onboard_result_config_path_is_nonempty() {
         let db = test_db();
+        let belt_home = test_belt_home();
         let tmp = write_workspace_yaml(VALID_YAML);
-        let result = onboard_workspace(&db, tmp.path()).unwrap();
+        let result = onboard_workspace(&db, tmp.path(), belt_home.path()).unwrap();
         assert!(!result.config_path.is_empty());
     }
 
     #[test]
     fn onboard_cron_jobs_have_correct_schedules() {
         let db = test_db();
+        let belt_home = test_belt_home();
         let tmp = write_workspace_yaml(VALID_YAML);
-        onboard_workspace(&db, tmp.path()).unwrap();
+        onboard_workspace(&db, tmp.path(), belt_home.path()).unwrap();
 
         let jobs = db.list_cron_jobs().unwrap();
         let job_map: std::collections::HashMap<&str, &str> = jobs
@@ -315,11 +399,12 @@ sources:
     fn onboard_triple_call_is_idempotent() {
         // Running onboard three times should not accumulate cron jobs.
         let db = test_db();
+        let belt_home = test_belt_home();
         let tmp = write_workspace_yaml(VALID_YAML);
 
-        onboard_workspace(&db, tmp.path()).unwrap();
-        onboard_workspace(&db, tmp.path()).unwrap();
-        let result3 = onboard_workspace(&db, tmp.path()).unwrap();
+        onboard_workspace(&db, tmp.path(), belt_home.path()).unwrap();
+        onboard_workspace(&db, tmp.path(), belt_home.path()).unwrap();
+        let result3 = onboard_workspace(&db, tmp.path(), belt_home.path()).unwrap();
 
         assert!(!result3.created);
         assert_eq!(result3.cron_jobs_seeded, 0);
@@ -329,8 +414,9 @@ sources:
     #[test]
     fn onboard_all_seeded_cron_jobs_are_enabled() {
         let db = test_db();
+        let belt_home = test_belt_home();
         let tmp = write_workspace_yaml(VALID_YAML);
-        onboard_workspace(&db, tmp.path()).unwrap();
+        onboard_workspace(&db, tmp.path(), belt_home.path()).unwrap();
 
         let jobs = db.list_cron_jobs().unwrap();
         for job in &jobs {
@@ -345,8 +431,9 @@ sources:
     #[test]
     fn onboard_cron_jobs_have_correct_workspace_scope() {
         let db = test_db();
+        let belt_home = test_belt_home();
         let tmp = write_workspace_yaml(VALID_YAML);
-        onboard_workspace(&db, tmp.path()).unwrap();
+        onboard_workspace(&db, tmp.path(), belt_home.path()).unwrap();
 
         let jobs = db.list_cron_jobs().unwrap();
         for job in &jobs {
@@ -357,5 +444,82 @@ sources:
                 job.name
             );
         }
+    }
+
+    #[test]
+    fn onboard_creates_per_workspace_claw_dir() {
+        let db = test_db();
+        let belt_home = test_belt_home();
+        let tmp = write_workspace_yaml(VALID_YAML);
+
+        let result = onboard_workspace(&db, tmp.path(), belt_home.path()).unwrap();
+
+        // Verify claw directory structure
+        let claw_dir = belt_home.path().join("workspaces/test-project/claw");
+        assert_eq!(result.claw_dir, claw_dir);
+        assert!(claw_dir.join("system").is_dir());
+        assert!(claw_dir.join("session").is_dir());
+        assert!(claw_dir.join("config.yaml").is_file());
+
+        // Verify config.yaml content
+        let config_content = std::fs::read_to_string(claw_dir.join("config.yaml")).unwrap();
+        assert!(config_content.contains("workspace: test-project"));
+    }
+
+    #[test]
+    fn onboard_claw_dir_is_idempotent() {
+        let db = test_db();
+        let belt_home = test_belt_home();
+        let tmp = write_workspace_yaml(VALID_YAML);
+
+        let result1 = onboard_workspace(&db, tmp.path(), belt_home.path()).unwrap();
+        let claw_dir = result1.claw_dir.clone();
+
+        // Write custom content to config.yaml
+        let custom = "# custom config\n";
+        std::fs::write(claw_dir.join("config.yaml"), custom).unwrap();
+
+        // Re-onboard should preserve existing config.yaml
+        let result2 = onboard_workspace(&db, tmp.path(), belt_home.path()).unwrap();
+        assert_eq!(result2.claw_dir, claw_dir);
+
+        let content = std::fs::read_to_string(claw_dir.join("config.yaml")).unwrap();
+        assert_eq!(content, custom, "existing config.yaml should be preserved");
+    }
+
+    #[test]
+    fn init_workspace_claw_dir_creates_structure() {
+        let belt_home = test_belt_home();
+        let claw_dir = init_workspace_claw_dir(belt_home.path(), "my-project").unwrap();
+
+        assert!(claw_dir.join("system").is_dir());
+        assert!(claw_dir.join("session").is_dir());
+        assert!(claw_dir.join("config.yaml").is_file());
+        assert_eq!(
+            claw_dir,
+            belt_home.path().join("workspaces/my-project/claw")
+        );
+    }
+
+    #[test]
+    fn multiple_workspaces_get_separate_claw_dirs() {
+        let db = test_db();
+        let belt_home = test_belt_home();
+        let yaml_a = "name: project-a\nsources:\n  github:\n    url: https://github.com/org/a\n";
+        let yaml_b = "name: project-b\nsources:\n  github:\n    url: https://github.com/org/b\n";
+        let tmp_a = write_workspace_yaml(yaml_a);
+        let tmp_b = write_workspace_yaml(yaml_b);
+
+        let result_a = onboard_workspace(&db, tmp_a.path(), belt_home.path()).unwrap();
+        let result_b = onboard_workspace(&db, tmp_b.path(), belt_home.path()).unwrap();
+
+        assert_ne!(result_a.claw_dir, result_b.claw_dir);
+        assert!(result_a.claw_dir.join("config.yaml").is_file());
+        assert!(result_b.claw_dir.join("config.yaml").is_file());
+
+        let content_a = std::fs::read_to_string(result_a.claw_dir.join("config.yaml")).unwrap();
+        let content_b = std::fs::read_to_string(result_b.claw_dir.join("config.yaml")).unwrap();
+        assert!(content_a.contains("workspace: project-a"));
+        assert!(content_b.contains("workspace: project-b"));
     }
 }


### PR DESCRIPTION
## Summary

Autopilot 자동 구현

Closes #143

## Changes

Implements per-workspace Claw directory creation to ensure each workspace maintains its own isolated Claw state directory, as specified in R-052.