### PR TITLE
feat: [gap] R-044: Implement belt spec link/unlink/verify commands

### DIFF
--- a/crates/belt-cli/src/main.rs
+++ b/crates/belt-cli/src/main.rs
@@ -361,6 +361,30 @@ enum SpecCommands {
         /// Spec ID.
         id: String,
     },
+    /// Link a spec to an external resource (URL or issue reference).
+    Link {
+        /// Spec ID.
+        id: String,
+        /// Target URL or issue reference (e.g. `https://...` or `owner/repo#123`).
+        #[arg(long)]
+        to: String,
+    },
+    /// Unlink a spec from an external resource.
+    Unlink {
+        /// Spec ID.
+        id: String,
+        /// Target URL or issue reference to remove.
+        #[arg(long)]
+        from: String,
+    },
+    /// Verify all links for a spec (check reachability).
+    Verify {
+        /// Spec ID.
+        id: String,
+        /// Output as JSON.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 /// Load workspace config and start the daemon loop.
@@ -1050,6 +1074,84 @@ fn truncate(s: &str, max: usize) -> String {
     }
 }
 
+/// Verify a link target by checking reachability.
+///
+/// For GitHub issue references (e.g. `owner/repo#123`), uses `gh issue view`.
+/// For HTTP(S) URLs, uses `curl --head`.
+/// Returns `(is_valid, detail_message)`.
+fn verify_link_target(target: &str) -> (bool, String) {
+    // Detect GitHub issue reference: owner/repo#number
+    if let Some((repo, number)) = parse_github_issue_ref(target) {
+        let output = std::process::Command::new("gh")
+            .args(["issue", "view", &number, "--repo", &repo, "--json", "state"])
+            .output();
+        match output {
+            Ok(out) if out.status.success() => {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                (true, format!("issue exists: {}", stdout.trim()))
+            }
+            Ok(out) => {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                (false, format!("gh issue view failed: {}", stderr.trim()))
+            }
+            Err(e) => (false, format!("could not run gh: {e}")),
+        }
+    } else if target.starts_with("http://") || target.starts_with("https://") {
+        let output = std::process::Command::new("curl")
+            .args([
+                "--head",
+                "--silent",
+                "--output",
+                "/dev/null",
+                "--write-out",
+                "%{http_code}",
+                "--max-time",
+                "10",
+                "--location",
+                target,
+            ])
+            .output();
+        match output {
+            Ok(out) if out.status.success() => {
+                let code = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                let code_num: u16 = code.parse().unwrap_or(0);
+                if (200..400).contains(&code_num) {
+                    (true, format!("HTTP {code}"))
+                } else {
+                    (false, format!("HTTP {code}"))
+                }
+            }
+            Ok(out) => {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                (false, format!("curl failed: {}", stderr.trim()))
+            }
+            Err(e) => (false, format!("could not run curl: {e}")),
+        }
+    } else {
+        (false, format!("unsupported target format: {target}"))
+    }
+}
+
+/// Parse a GitHub issue reference like `owner/repo#123` into `(owner/repo, 123)`.
+fn parse_github_issue_ref(target: &str) -> Option<(String, String)> {
+    // Match patterns: owner/repo#123
+    let parts: Vec<&str> = target.splitn(2, '#').collect();
+    if parts.len() == 2 {
+        let repo = parts[0];
+        let number = parts[1];
+        // Validate: repo should contain exactly one '/', number should be digits
+        if repo.matches('/').count() == 1
+            && !repo.starts_with('/')
+            && !repo.ends_with('/')
+            && number.chars().all(|c| c.is_ascii_digit())
+            && !number.is_empty()
+        {
+            return Some((repo.to_string(), number.to_string()));
+        }
+    }
+    None
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -1169,7 +1271,9 @@ async fn main() -> anyhow::Result<()> {
                         println!("Workspace '{}' updated.", name);
                         println!("  Config: {}", abs_path);
                     } else {
-                        println!("No update options provided. Use --config to update the config path.");
+                        println!(
+                            "No update options provided. Use --config to update the config path."
+                        );
                     }
                 }
                 WorkspaceCommands::Remove { name, force } => {
@@ -1605,8 +1709,54 @@ async fn main() -> anyhow::Result<()> {
                     }
                 }
                 SpecCommands::Remove { id } => {
+                    db.remove_all_spec_links(&id)?;
                     db.remove_spec(&id)?;
                     println!("spec removed: {id}");
+                }
+                SpecCommands::Link { id, to } => {
+                    // Ensure spec exists.
+                    let _ = db.get_spec(&id)?;
+                    let link_id = format!("link-{}", chrono::Utc::now().timestamp_millis());
+                    let link =
+                        belt_core::spec::SpecLink::new(link_id.clone(), id.clone(), to.clone());
+                    db.insert_spec_link(&link)?;
+                    println!("linked {id} -> {to}");
+                }
+                SpecCommands::Unlink { id, from } => {
+                    db.remove_spec_link(&id, &from)?;
+                    println!("unlinked {id} -x- {from}");
+                }
+                SpecCommands::Verify { id, json } => {
+                    let _ = db.get_spec(&id)?;
+                    let links = db.list_spec_links(&id)?;
+                    if links.is_empty() {
+                        if json {
+                            println!("[]");
+                        } else {
+                            println!("no links found for spec {id}");
+                        }
+                    } else {
+                        let mut results: Vec<belt_core::spec::LinkVerification> = Vec::new();
+                        for link in links {
+                            let (valid, detail) = verify_link_target(&link.target);
+                            results.push(belt_core::spec::LinkVerification {
+                                link,
+                                valid,
+                                detail,
+                            });
+                        }
+                        if json {
+                            println!("{}", serde_json::to_string_pretty(&results)?);
+                        } else {
+                            for r in &results {
+                                let status_icon = if r.valid { "OK" } else { "FAIL" };
+                                println!("[{status_icon}] {} - {}", r.link.target, r.detail);
+                            }
+                            let total = results.len();
+                            let passed = results.iter().filter(|r| r.valid).count();
+                            println!("\n{passed}/{total} links verified successfully");
+                        }
+                    }
                 }
             }
         }
@@ -1771,4 +1921,54 @@ async fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_github_issue_ref_valid() {
+        let result = parse_github_issue_ref("owner/repo#123");
+        assert_eq!(result, Some(("owner/repo".to_string(), "123".to_string())));
+    }
+
+    #[test]
+    fn parse_github_issue_ref_url_not_matched() {
+        // Full URLs are not issue refs.
+        assert_eq!(
+            parse_github_issue_ref("https://github.com/owner/repo/issues/1"),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_github_issue_ref_no_hash() {
+        assert_eq!(parse_github_issue_ref("owner/repo"), None);
+    }
+
+    #[test]
+    fn parse_github_issue_ref_no_number() {
+        assert_eq!(parse_github_issue_ref("owner/repo#abc"), None);
+    }
+
+    #[test]
+    fn parse_github_issue_ref_no_slash() {
+        assert_eq!(parse_github_issue_ref("repo#123"), None);
+    }
+
+    #[test]
+    fn parse_github_issue_ref_leading_slash() {
+        assert_eq!(parse_github_issue_ref("/repo#123"), None);
+    }
+
+    #[test]
+    fn parse_github_issue_ref_trailing_slash() {
+        assert_eq!(parse_github_issue_ref("owner/#123"), None);
+    }
+
+    #[test]
+    fn parse_github_issue_ref_empty_number() {
+        assert_eq!(parse_github_issue_ref("owner/repo#"), None);
+    }
 }

--- a/crates/belt-core/src/spec.rs
+++ b/crates/belt-core/src/spec.rs
@@ -121,6 +121,43 @@ impl fmt::Display for SpecTransitionError {
 
 impl std::error::Error for SpecTransitionError {}
 
+/// A link between a spec and an external resource (URL or issue ID).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpecLink {
+    /// Unique identifier for this link.
+    pub id: String,
+    /// The spec this link belongs to.
+    pub spec_id: String,
+    /// The target resource (URL or issue reference like `owner/repo#123`).
+    pub target: String,
+    /// Creation timestamp (RFC 3339).
+    pub created_at: String,
+}
+
+impl SpecLink {
+    /// Create a new spec link.
+    pub fn new(id: String, spec_id: String, target: String) -> Self {
+        let now = chrono::Utc::now().to_rfc3339();
+        Self {
+            id,
+            spec_id,
+            target,
+            created_at: now,
+        }
+    }
+}
+
+/// Result of verifying a single spec link.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LinkVerification {
+    /// The link that was verified.
+    pub link: SpecLink,
+    /// Whether the link target is reachable / valid.
+    pub valid: bool,
+    /// Human-readable detail (e.g. HTTP status or error message).
+    pub detail: String,
+}
+
 /// A spec represents a planned unit of work with lifecycle management.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Spec {
@@ -309,6 +346,51 @@ mod tests {
             "content".to_string(),
         );
         assert!(spec.transition_to(Completed).is_err());
+    }
+
+    #[test]
+    fn spec_link_new() {
+        let link = SpecLink::new(
+            "link-1".to_string(),
+            "spec-1".to_string(),
+            "https://github.com/org/repo/issues/42".to_string(),
+        );
+        assert_eq!(link.id, "link-1");
+        assert_eq!(link.spec_id, "spec-1");
+        assert_eq!(link.target, "https://github.com/org/repo/issues/42");
+        assert!(!link.created_at.is_empty());
+    }
+
+    #[test]
+    fn spec_link_json_roundtrip() {
+        let link = SpecLink::new(
+            "link-1".to_string(),
+            "spec-1".to_string(),
+            "https://example.com".to_string(),
+        );
+        let json = serde_json::to_string(&link).unwrap();
+        let parsed: SpecLink = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.id, link.id);
+        assert_eq!(parsed.spec_id, link.spec_id);
+        assert_eq!(parsed.target, link.target);
+    }
+
+    #[test]
+    fn link_verification_json_roundtrip() {
+        let link = SpecLink::new(
+            "link-1".to_string(),
+            "spec-1".to_string(),
+            "https://example.com".to_string(),
+        );
+        let verification = LinkVerification {
+            link,
+            valid: true,
+            detail: "200 OK".to_string(),
+        };
+        let json = serde_json::to_string(&verification).unwrap();
+        let parsed: LinkVerification = serde_json::from_str(&json).unwrap();
+        assert!(parsed.valid);
+        assert_eq!(parsed.detail, "200 OK");
     }
 
     #[test]

--- a/crates/belt-infra/src/db.rs
+++ b/crates/belt-infra/src/db.rs
@@ -14,7 +14,7 @@ use belt_core::error::BeltError;
 use belt_core::phase::QueuePhase;
 use belt_core::queue::QueueItem;
 use belt_core::runtime::TokenUsage;
-use belt_core::spec::{Spec, SpecStatus};
+use belt_core::spec::{Spec, SpecLink, SpecStatus};
 
 /// An immutable history event recording an attempt on a work item.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -280,6 +280,14 @@ impl Database {
                 depends_on   TEXT,
                 created_at   TEXT NOT NULL,
                 updated_at   TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS spec_links (
+                id         TEXT PRIMARY KEY,
+                spec_id    TEXT NOT NULL,
+                target     TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                UNIQUE(spec_id, target)
             );
 
             CREATE TABLE IF NOT EXISTS transition_events (
@@ -1084,6 +1092,89 @@ impl Database {
             return Err(BeltError::SpecNotFound(id.to_string()));
         }
         Ok(())
+    }
+
+    // ---- Spec Links ---------------------------------------------------------
+
+    /// Insert a new spec link (association between a spec and an external resource).
+    ///
+    /// # Errors
+    /// Returns `BeltError::Database` on constraint violation.
+    pub fn insert_spec_link(&self, link: &SpecLink) -> Result<(), BeltError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        conn.execute(
+            "INSERT INTO spec_links (id, spec_id, target, created_at) VALUES (?1, ?2, ?3, ?4)",
+            params![link.id, link.spec_id, link.target, link.created_at],
+        )
+        .map_err(|e| BeltError::Database(e.to_string()))?;
+        Ok(())
+    }
+
+    /// List all links for a given spec.
+    pub fn list_spec_links(&self, spec_id: &str) -> Result<Vec<SpecLink>, BeltError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, spec_id, target, created_at FROM spec_links WHERE spec_id = ?1 ORDER BY created_at ASC",
+            )
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        let links = stmt
+            .query_map(params![spec_id], |row| {
+                Ok(SpecLink {
+                    id: row.get(0)?,
+                    spec_id: row.get(1)?,
+                    target: row.get(2)?,
+                    created_at: row.get(3)?,
+                })
+            })
+            .map_err(|e| BeltError::Database(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        Ok(links)
+    }
+
+    /// Remove a spec link by spec_id and target.
+    ///
+    /// # Errors
+    /// Returns `BeltError::Database` with a descriptive message if no matching link exists.
+    pub fn remove_spec_link(&self, spec_id: &str, target: &str) -> Result<(), BeltError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        let rows = conn
+            .execute(
+                "DELETE FROM spec_links WHERE spec_id = ?1 AND target = ?2",
+                params![spec_id, target],
+            )
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        if rows == 0 {
+            return Err(BeltError::Database(format!(
+                "no link found for spec '{spec_id}' with target '{target}'"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Remove all links for a spec (used when removing a spec).
+    pub fn remove_all_spec_links(&self, spec_id: &str) -> Result<usize, BeltError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        let rows = conn
+            .execute(
+                "DELETE FROM spec_links WHERE spec_id = ?1",
+                params![spec_id],
+            )
+            .map_err(|e| BeltError::Database(e.to_string()))?;
+        Ok(rows)
     }
 
     // ---- Knowledge Base ----------------------------------------------------
@@ -2348,6 +2439,102 @@ mod tests {
         for s in statuses {
             assert_eq!(str_to_spec_status(s.as_str()).unwrap(), s);
         }
+    }
+
+    // ---- Spec links -----------------------------------------------------------
+
+    #[test]
+    fn insert_and_list_spec_links() {
+        let db = test_db();
+        let spec = sample_spec();
+        db.insert_spec(&spec).unwrap();
+
+        let link = SpecLink::new(
+            "link-1".to_string(),
+            spec.id.clone(),
+            "https://example.com".to_string(),
+        );
+        db.insert_spec_link(&link).unwrap();
+
+        let links = db.list_spec_links(&spec.id).unwrap();
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "https://example.com");
+    }
+
+    #[test]
+    fn remove_spec_link() {
+        let db = test_db();
+        let spec = sample_spec();
+        db.insert_spec(&spec).unwrap();
+
+        let link = SpecLink::new(
+            "link-1".to_string(),
+            spec.id.clone(),
+            "https://example.com".to_string(),
+        );
+        db.insert_spec_link(&link).unwrap();
+        db.remove_spec_link(&spec.id, "https://example.com")
+            .unwrap();
+
+        let links = db.list_spec_links(&spec.id).unwrap();
+        assert!(links.is_empty());
+    }
+
+    #[test]
+    fn remove_spec_link_not_found() {
+        let db = test_db();
+        let err = db
+            .remove_spec_link("nonexistent", "https://example.com")
+            .unwrap_err();
+        assert!(matches!(err, BeltError::Database(_)));
+    }
+
+    #[test]
+    fn remove_all_spec_links() {
+        let db = test_db();
+        let spec = sample_spec();
+        db.insert_spec(&spec).unwrap();
+
+        let link1 = SpecLink::new(
+            "link-1".to_string(),
+            spec.id.clone(),
+            "https://example.com".to_string(),
+        );
+        let link2 = SpecLink::new(
+            "link-2".to_string(),
+            spec.id.clone(),
+            "https://other.com".to_string(),
+        );
+        db.insert_spec_link(&link1).unwrap();
+        db.insert_spec_link(&link2).unwrap();
+
+        let removed = db.remove_all_spec_links(&spec.id).unwrap();
+        assert_eq!(removed, 2);
+
+        let links = db.list_spec_links(&spec.id).unwrap();
+        assert!(links.is_empty());
+    }
+
+    #[test]
+    fn duplicate_spec_link_rejected() {
+        let db = test_db();
+        let spec = sample_spec();
+        db.insert_spec(&spec).unwrap();
+
+        let link = SpecLink::new(
+            "link-1".to_string(),
+            spec.id.clone(),
+            "https://example.com".to_string(),
+        );
+        db.insert_spec_link(&link).unwrap();
+
+        let link2 = SpecLink::new(
+            "link-2".to_string(),
+            spec.id.clone(),
+            "https://example.com".to_string(),
+        );
+        let err = db.insert_spec_link(&link2).unwrap_err();
+        assert!(matches!(err, BeltError::Database(_)));
     }
 
     // ---- HITL metadata --------------------------------------------------------


### PR DESCRIPTION
## Summary

Autopilot 자동 구현

Closes #142

## Changes

Implement belt spec link/unlink/verify commands to manage relationships between specs and enable spec verification in the workflow.