### PR TITLE
feat: [Gap] Clarify retry worktree handoff from preserved item to new item

### DIFF
--- a/crates/belt-cli/src/status.rs
+++ b/crates/belt-cli/src/status.rs
@@ -469,7 +469,6 @@ mod tests {
     }
 }
 
-
 fn print_text_status(status: &SystemStatus) {
     println!("Belt System Status");
     println!("==================");

--- a/crates/belt-core/src/queue.rs
+++ b/crates/belt-core/src/queue.rs
@@ -141,6 +141,12 @@ pub struct QueueItem {
     /// cleanup 없이 보존되었음을 명시적으로 기록한다.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub worktree_preserved: bool,
+    /// 이전 아이템(보존된)의 worktree 경로.
+    ///
+    /// Retry 아이템 생성 시 실패한 원본 아이템의 worktree 경로를 저장하여
+    /// `WorktreeManager::create_or_reuse`가 기존 worktree를 재사용할 수 있게 한다.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_worktree_path: Option<String>,
 }
 
 impl QueueItem {
@@ -162,6 +168,7 @@ impl QueueItem {
             hitl_timeout_at: None,
             hitl_terminal_action: None,
             worktree_preserved: false,
+            previous_worktree_path: None,
         }
     }
 
@@ -190,6 +197,7 @@ pub struct QueueItemRow {
     pub hitl_timeout_at: Option<String>,
     pub hitl_terminal_action: Option<String>,
     pub worktree_preserved: bool,
+    pub previous_worktree_path: Option<String>,
 }
 
 impl QueueItem {
@@ -210,6 +218,7 @@ impl QueueItem {
             hitl_timeout_at: self.hitl_timeout_at.clone(),
             hitl_terminal_action: self.hitl_terminal_action.clone(),
             worktree_preserved: self.worktree_preserved,
+            previous_worktree_path: self.previous_worktree_path.clone(),
         }
     }
 
@@ -242,6 +251,7 @@ impl QueueItem {
             hitl_timeout_at: row.hitl_timeout_at.clone(),
             hitl_terminal_action: row.hitl_terminal_action.clone(),
             worktree_preserved: row.worktree_preserved,
+            previous_worktree_path: row.previous_worktree_path.clone(),
         })
     }
 
@@ -276,6 +286,7 @@ pub mod testing {
             hitl_timeout_at: None,
             hitl_terminal_action: None,
             worktree_preserved: false,
+            previous_worktree_path: None,
         }
     }
 }
@@ -409,5 +420,42 @@ mod tests {
         assert!(row.worktree_preserved);
         let restored = QueueItem::from_row(&row).unwrap();
         assert!(restored.worktree_preserved);
+    }
+
+    #[test]
+    fn previous_worktree_path_default_none() {
+        let item = test_item("s1", "analyze");
+        assert!(item.previous_worktree_path.is_none());
+    }
+
+    #[test]
+    fn previous_worktree_path_skipped_in_json_when_none() {
+        let item = test_item("s1", "analyze");
+        let json = serde_json::to_string(&item).unwrap();
+        assert!(!json.contains("previous_worktree_path"));
+    }
+
+    #[test]
+    fn previous_worktree_path_present_in_json_when_set() {
+        let mut item = test_item("s1", "analyze");
+        item.previous_worktree_path = Some("/tmp/worktrees/old-item".to_string());
+        let json = serde_json::to_string(&item).unwrap();
+        assert!(json.contains("\"previous_worktree_path\":\"/tmp/worktrees/old-item\""));
+    }
+
+    #[test]
+    fn previous_worktree_path_row_roundtrip() {
+        let mut item = test_item("s1", "analyze");
+        item.previous_worktree_path = Some("/tmp/worktrees/old-item".to_string());
+        let row = item.to_row();
+        assert_eq!(
+            row.previous_worktree_path.as_deref(),
+            Some("/tmp/worktrees/old-item")
+        );
+        let restored = QueueItem::from_row(&row).unwrap();
+        assert_eq!(
+            restored.previous_worktree_path.as_deref(),
+            Some("/tmp/worktrees/old-item")
+        );
     }
 }

--- a/crates/belt-daemon/src/daemon.rs
+++ b/crates/belt-daemon/src/daemon.rs
@@ -404,8 +404,13 @@ impl Daemon {
         // Collect on_fail actions for deferred, escalation-aware execution.
         let on_fail_actions: Vec<Action> = state_config.on_fail.iter().map(Action::from).collect();
 
-        let worktree = match worktree_mgr.create_or_reuse(&ws_name) {
-            Ok(path) => path,
+        let previous_wt = item.previous_worktree_path.as_deref();
+        let worktree = match worktree_mgr.create_or_reuse_with_previous(&ws_name, previous_wt) {
+            Ok(path) => {
+                // Clear the previous_worktree_path after successful handoff.
+                item.previous_worktree_path = None;
+                path
+            }
             Err(e) => {
                 item.phase = QueuePhase::Failed;
                 return ExecutionResult {
@@ -1169,6 +1174,19 @@ impl Daemon {
                 let mut retry_item = item.clone();
                 retry_item.phase = QueuePhase::Pending;
                 retry_item.updated_at = now;
+                // Carry over the preserved worktree path so the retry item
+                // can reuse the existing working tree via create_or_reuse_with_previous.
+                if item.worktree_preserved {
+                    let prev_path = self.worktree_mgr.path(&item.work_id);
+                    retry_item.previous_worktree_path =
+                        Some(prev_path.to_string_lossy().into_owned());
+                    tracing::info!(
+                        work_id = %item.work_id,
+                        ?prev_path,
+                        "storing preserved worktree path for retry item"
+                    );
+                }
+                retry_item.worktree_preserved = false;
                 self.queue.push_back(retry_item);
             }
             EscalationAction::Skip => {

--- a/crates/belt-infra/src/db.rs
+++ b/crates/belt-infra/src/db.rs
@@ -1846,6 +1846,8 @@ fn row_to_queue_item(row: &rusqlite::Row<'_>) -> Result<QueueItem, BeltError> {
             .get(13)
             .map_err(|e| BeltError::Database(e.to_string()))?,
         worktree_preserved: false,
+        // previous_worktree_path is transient (in-memory only, not persisted to DB).
+        previous_worktree_path: None,
     })
 }
 
@@ -1874,6 +1876,7 @@ mod tests {
             hitl_timeout_at: None,
             hitl_terminal_action: None,
             worktree_preserved: false,
+            previous_worktree_path: None,
         }
     }
 

--- a/crates/belt-infra/src/sources/github.rs
+++ b/crates/belt-infra/src/sources/github.rs
@@ -416,6 +416,7 @@ impl DataSource for GitHubDataSource {
                                 hitl_timeout_at: None,
                                 hitl_terminal_action: None,
                                 worktree_preserved: false,
+                                previous_worktree_path: None,
                             });
                         }
                     }

--- a/crates/belt-infra/src/worktree.rs
+++ b/crates/belt-infra/src/worktree.rs
@@ -11,6 +11,24 @@ pub trait WorktreeManager: Send + Sync {
     /// Creates a worktree or reuses an existing one for the given `work_id`.
     fn create_or_reuse(&self, work_id: &str) -> Result<PathBuf, BeltError>;
 
+    /// Creates a worktree or reuses an existing one, optionally reusing a
+    /// preserved worktree from a previous (failed) item.
+    ///
+    /// When `previous_worktree_path` is provided and the directory exists,
+    /// the implementation renames/moves it to the new work_id location so
+    /// that the retry item inherits the preserved working tree state.
+    /// Falls back to [`create_or_reuse`](Self::create_or_reuse) when the
+    /// previous path is `None` or does not exist.
+    fn create_or_reuse_with_previous(
+        &self,
+        work_id: &str,
+        previous_worktree_path: Option<&str>,
+    ) -> Result<PathBuf, BeltError> {
+        // Default implementation: ignore previous path and delegate.
+        let _ = previous_worktree_path;
+        self.create_or_reuse(work_id)
+    }
+
     /// Cleans up a worktree (`git worktree remove` + branch deletion).
     fn cleanup(&self, work_id: &str) -> Result<(), BeltError>;
 
@@ -61,6 +79,60 @@ impl GitWorktreeManager {
 }
 
 impl WorktreeManager for GitWorktreeManager {
+    fn create_or_reuse_with_previous(
+        &self,
+        work_id: &str,
+        previous_worktree_path: Option<&str>,
+    ) -> Result<PathBuf, BeltError> {
+        let wt_path = self.path(work_id);
+
+        if wt_path.exists() {
+            tracing::debug!(work_id, ?wt_path, "worktree already exists, reusing");
+            return Ok(wt_path);
+        }
+
+        // If a previous worktree path is provided and exists on disk, rename
+        // it to the new location so the retry item inherits the preserved state.
+        if let Some(prev) = previous_worktree_path {
+            let prev_path = PathBuf::from(prev);
+            if prev_path.exists() {
+                tracing::info!(
+                    work_id,
+                    ?prev_path,
+                    ?wt_path,
+                    "reusing preserved worktree from previous item"
+                );
+
+                // git worktree move <old> <new>
+                let output = Command::new("git")
+                    .args(["worktree", "move"])
+                    .arg(&prev_path)
+                    .arg(&wt_path)
+                    .current_dir(&self.repo_path)
+                    .output()
+                    .map_err(|e| {
+                        BeltError::Worktree(format!("failed to run git worktree move: {e}"))
+                    })?;
+
+                if output.status.success() {
+                    tracing::info!(work_id, ?wt_path, "worktree moved from preserved location");
+                    return Ok(wt_path);
+                }
+
+                // Move failed — fall through to normal creation.
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                tracing::warn!(
+                    work_id,
+                    ?prev_path,
+                    "git worktree move failed, falling back to fresh create: {stderr}"
+                );
+            }
+        }
+
+        // Fallback to normal creation.
+        self.create_or_reuse(work_id)
+    }
+
     fn create_or_reuse(&self, work_id: &str) -> Result<PathBuf, BeltError> {
         let wt_path = self.path(work_id);
 
@@ -157,6 +229,33 @@ impl MockWorktreeManager {
 }
 
 impl WorktreeManager for MockWorktreeManager {
+    fn create_or_reuse_with_previous(
+        &self,
+        work_id: &str,
+        previous_worktree_path: Option<&str>,
+    ) -> Result<PathBuf, BeltError> {
+        let wt_path = self.path(work_id);
+
+        if wt_path.exists() {
+            return Ok(wt_path);
+        }
+
+        // If a previous worktree directory exists, rename it for the new work_id.
+        if let Some(prev) = previous_worktree_path {
+            let prev_path = PathBuf::from(prev);
+            if prev_path.exists() {
+                std::fs::rename(&prev_path, &wt_path).map_err(|e| {
+                    BeltError::Worktree(format!(
+                        "failed to rename previous worktree {prev_path:?} to {wt_path:?}: {e}"
+                    ))
+                })?;
+                return Ok(wt_path);
+            }
+        }
+
+        self.create_or_reuse(work_id)
+    }
+
     fn create_or_reuse(&self, work_id: &str) -> Result<PathBuf, BeltError> {
         let wt_path = self.path(work_id);
 
@@ -337,5 +436,67 @@ mod tests {
         // cleanup
         mgr.cleanup("task-1").unwrap();
         assert!(!mgr.exists("task-1"));
+    }
+
+    #[test]
+    fn mock_create_or_reuse_with_previous_renames_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = MockWorktreeManager::new(tmp.path().to_path_buf());
+
+        // Create a "previous" worktree with some content.
+        let prev_path = mgr.create_or_reuse("old-work").unwrap();
+        fs::write(prev_path.join("state.txt"), "preserved").unwrap();
+
+        // Create the retry worktree reusing the previous one.
+        let new_path = mgr
+            .create_or_reuse_with_previous("new-work", Some(prev_path.to_str().unwrap()))
+            .unwrap();
+
+        // New path should exist with the preserved content.
+        assert!(new_path.exists());
+        assert_eq!(
+            fs::read_to_string(new_path.join("state.txt")).unwrap(),
+            "preserved"
+        );
+
+        // Old path should no longer exist (it was renamed).
+        assert!(!prev_path.exists());
+    }
+
+    #[test]
+    fn mock_create_or_reuse_with_previous_none_falls_back() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = MockWorktreeManager::new(tmp.path().to_path_buf());
+
+        let path = mgr.create_or_reuse_with_previous("work-1", None).unwrap();
+        assert!(path.exists());
+        assert!(path.is_dir());
+    }
+
+    #[test]
+    fn mock_create_or_reuse_with_previous_nonexistent_falls_back() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = MockWorktreeManager::new(tmp.path().to_path_buf());
+
+        let path = mgr
+            .create_or_reuse_with_previous("work-1", Some("/nonexistent/path"))
+            .unwrap();
+        assert!(path.exists());
+        assert!(path.is_dir());
+    }
+
+    #[test]
+    fn mock_create_or_reuse_with_previous_existing_target_reuses() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = MockWorktreeManager::new(tmp.path().to_path_buf());
+
+        // Pre-create the target directory.
+        let existing = mgr.create_or_reuse("work-1").unwrap();
+
+        // Even with a previous path, the existing target takes precedence.
+        let path = mgr
+            .create_or_reuse_with_previous("work-1", Some("/some/old/path"))
+            .unwrap();
+        assert_eq!(path, existing);
     }
 }


### PR DESCRIPTION
## Summary

Autopilot 자동 구현

Closes #191

## Changes

Implement retry worktree handoff logic from preserved item to new item, clarifying the gap in item state transitions during retry operations.