### PR TITLE
feat: [Gap] Implement HITL replan action to delegate spec modification to Claw

### DIFF
--- a/crates/belt-cli/src/main.rs
+++ b/crates/belt-cli/src/main.rs
@@ -2260,17 +2260,61 @@ async fn main() -> anyhow::Result<()> {
                         item.phase
                     );
                 }
-                let target_phase = match action {
-                    belt_core::queue::HitlRespondAction::Done => QueuePhase::Done,
-                    belt_core::queue::HitlRespondAction::Retry => QueuePhase::Pending,
-                    belt_core::queue::HitlRespondAction::Skip => QueuePhase::Skipped,
-                    belt_core::queue::HitlRespondAction::Replan => QueuePhase::Failed,
-                };
-                db.update_phase(&item_id, target_phase)?;
-                println!(
-                    "Item '{}' transitioned from hitl to {} (action: {}).",
-                    item_id, target_phase, action
-                );
+                match action {
+                    belt_core::queue::HitlRespondAction::Replan => {
+                        let max_replan = 3u32;
+                        let new_count = item.replan_count + 1;
+                        if new_count > max_replan {
+                            db.update_phase(&item_id, QueuePhase::Failed)?;
+                            println!(
+                                "Item '{}' replan limit exceeded ({}/{}), transitioned to failed.",
+                                item_id, new_count, max_replan
+                            );
+                        } else {
+                            // Roll back original item to Pending.
+                            db.update_phase(&item_id, QueuePhase::Pending)?;
+                            // Create a spec-modification-proposed HITL item.
+                            let failure_reason =
+                                item.hitl_notes.as_deref().unwrap_or("unknown failure");
+                            let replan_work_id = format!("{item_id}:replan-{new_count}");
+                            let mut replan_item = belt_core::queue::QueueItem::new(
+                                replan_work_id.clone(),
+                                item.source_id.clone(),
+                                item.workspace_id.clone(),
+                                item.state.clone(),
+                            );
+                            replan_item.phase = QueuePhase::Hitl;
+                            replan_item.hitl_created_at = Some(chrono::Utc::now().to_rfc3339());
+                            replan_item.hitl_reason =
+                                Some(belt_core::queue::HitlReason::SpecModificationProposed);
+                            replan_item.hitl_notes = Some(format!(
+                                "Claw replan delegation (attempt {new_count}): {failure_reason}"
+                            ));
+                            replan_item.title =
+                                Some(format!("spec-modification-proposed (replan #{new_count})"));
+                            replan_item.replan_count = new_count;
+                            db.insert_item(&replan_item)?;
+                            println!(
+                                "Item '{}' rolled back to pending (replan {}/{}). \
+                                 Created HITL item '{}' for spec modification review.",
+                                item_id, new_count, max_replan, replan_work_id
+                            );
+                        }
+                    }
+                    _ => {
+                        let target_phase = match action {
+                            belt_core::queue::HitlRespondAction::Done => QueuePhase::Done,
+                            belt_core::queue::HitlRespondAction::Retry => QueuePhase::Pending,
+                            belt_core::queue::HitlRespondAction::Skip => QueuePhase::Skipped,
+                            belt_core::queue::HitlRespondAction::Replan => unreachable!(),
+                        };
+                        db.update_phase(&item_id, target_phase)?;
+                        println!(
+                            "Item '{}' transitioned from hitl to {} (action: {}).",
+                            item_id, target_phase, action
+                        );
+                    }
+                }
             }
             HitlCommands::List { workspace } => {
                 tracing::info!(?workspace, "listing HITL items...");

--- a/crates/belt-core/src/error.rs
+++ b/crates/belt-core/src/error.rs
@@ -30,4 +30,11 @@ pub enum BeltError {
 
     #[error("invalid spec transition: {from} -> {to}")]
     InvalidSpecTransition { from: String, to: String },
+
+    #[error("replan limit exceeded for {work_id}: {count} attempts (max {max})")]
+    ReplanLimitExceeded {
+        work_id: String,
+        count: u32,
+        max: u32,
+    },
 }

--- a/crates/belt-core/src/queue.rs
+++ b/crates/belt-core/src/queue.rs
@@ -21,6 +21,8 @@ pub enum HitlReason {
     SpecConflict,
     /// spec Completing 단계 최종 확인 (gap-detection 통과 후 HITL 승인 대기).
     SpecCompletionReview,
+    /// Claw 에이전트가 제안한 스펙 수정.
+    SpecModificationProposed,
 }
 
 impl fmt::Display for HitlReason {
@@ -32,6 +34,7 @@ impl fmt::Display for HitlReason {
             HitlReason::ManualEscalation => f.write_str("manual_escalation"),
             HitlReason::SpecConflict => f.write_str("spec_conflict"),
             HitlReason::SpecCompletionReview => f.write_str("spec_completion_review"),
+            HitlReason::SpecModificationProposed => f.write_str("spec_modification_proposed"),
         }
     }
 }
@@ -153,6 +156,13 @@ pub struct QueueItem {
     /// `WorktreeManager::create_or_reuse`가 기존 worktree를 재사용할 수 있게 한다.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub previous_worktree_path: Option<String>,
+    /// Replan 시도 횟수. 무한 루프 방지를 위해 최대 3회로 제한한다.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub replan_count: u32,
+}
+
+fn is_zero(v: &u32) -> bool {
+    *v == 0
 }
 
 impl QueueItem {
@@ -175,6 +185,7 @@ impl QueueItem {
             hitl_terminal_action: None,
             worktree_preserved: false,
             previous_worktree_path: None,
+            replan_count: 0,
         }
     }
 
@@ -204,6 +215,7 @@ pub struct QueueItemRow {
     pub hitl_terminal_action: Option<String>,
     pub worktree_preserved: bool,
     pub previous_worktree_path: Option<String>,
+    pub replan_count: u32,
 }
 
 impl QueueItem {
@@ -225,6 +237,7 @@ impl QueueItem {
             hitl_terminal_action: self.hitl_terminal_action.clone(),
             worktree_preserved: self.worktree_preserved,
             previous_worktree_path: self.previous_worktree_path.clone(),
+            replan_count: self.replan_count,
         }
     }
 
@@ -239,6 +252,8 @@ impl QueueItem {
                 "timeout" => Ok(HitlReason::Timeout),
                 "manual_escalation" => Ok(HitlReason::ManualEscalation),
                 "spec_conflict" => Ok(HitlReason::SpecConflict),
+                "spec_completion_review" => Ok(HitlReason::SpecCompletionReview),
+                "spec_modification_proposed" => Ok(HitlReason::SpecModificationProposed),
                 other => Err(format!("invalid hitl_reason: {other}")),
             })
             .transpose()?;
@@ -259,6 +274,7 @@ impl QueueItem {
             hitl_terminal_action: row.hitl_terminal_action.clone(),
             worktree_preserved: row.worktree_preserved,
             previous_worktree_path: row.previous_worktree_path.clone(),
+            replan_count: row.replan_count,
         })
     }
 
@@ -294,6 +310,7 @@ pub mod testing {
             hitl_terminal_action: None,
             worktree_preserved: false,
             previous_worktree_path: None,
+            replan_count: 0,
         }
     }
 }
@@ -390,6 +407,10 @@ mod tests {
             "manual_escalation"
         );
         assert_eq!(HitlReason::SpecConflict.to_string(), "spec_conflict");
+        assert_eq!(
+            HitlReason::SpecModificationProposed.to_string(),
+            "spec_modification_proposed"
+        );
     }
 
     #[test]
@@ -464,6 +485,53 @@ mod tests {
         assert_eq!(
             restored.previous_worktree_path.as_deref(),
             Some("/tmp/worktrees/old-item")
+        );
+    }
+
+    #[test]
+    fn replan_count_default_zero() {
+        let item = test_item("s1", "analyze");
+        assert_eq!(item.replan_count, 0);
+    }
+
+    #[test]
+    fn replan_count_skipped_in_json_when_zero() {
+        let item = test_item("s1", "analyze");
+        let json = serde_json::to_string(&item).unwrap();
+        assert!(!json.contains("replan_count"));
+    }
+
+    #[test]
+    fn replan_count_present_in_json_when_nonzero() {
+        let mut item = test_item("s1", "analyze");
+        item.replan_count = 2;
+        let json = serde_json::to_string(&item).unwrap();
+        assert!(json.contains("\"replan_count\":2"));
+    }
+
+    #[test]
+    fn replan_count_row_roundtrip() {
+        let mut item = test_item("s1", "analyze");
+        item.replan_count = 3;
+        let row = item.to_row();
+        assert_eq!(row.replan_count, 3);
+        let restored = QueueItem::from_row(&row).unwrap();
+        assert_eq!(restored.replan_count, 3);
+    }
+
+    #[test]
+    fn spec_modification_proposed_reason_roundtrip() {
+        let mut item = test_item("s1", "analyze");
+        item.hitl_reason = Some(HitlReason::SpecModificationProposed);
+        let row = item.to_row();
+        assert_eq!(
+            row.hitl_reason.as_deref(),
+            Some("spec_modification_proposed")
+        );
+        let restored = QueueItem::from_row(&row).unwrap();
+        assert_eq!(
+            restored.hitl_reason,
+            Some(HitlReason::SpecModificationProposed)
         );
     }
 }

--- a/crates/belt-daemon/src/daemon.rs
+++ b/crates/belt-daemon/src/daemon.rs
@@ -757,9 +757,17 @@ impl Daemon {
         transit(item, QueuePhase::Pending)
     }
 
+    /// Maximum number of replan attempts before failing permanently.
+    const MAX_REPLAN_COUNT: u32 = 3;
+
     /// Respond to a HITL item with a user action.
     ///
     /// Applies the given [`HitlRespondAction`] and records the respondent.
+    ///
+    /// For `Replan`, the item is rolled back to Pending with an incremented
+    /// `replan_count`, and a new HITL item is created to delegate spec
+    /// modification to the Claw agent. If `replan_count` exceeds
+    /// [`Self::MAX_REPLAN_COUNT`], the item transitions to Failed instead.
     pub fn respond_hitl(
         &mut self,
         work_id: &str,
@@ -789,7 +797,61 @@ impl Daemon {
             HitlRespondAction::Done => transit(item, QueuePhase::Done),
             HitlRespondAction::Retry => transit(item, QueuePhase::Pending),
             HitlRespondAction::Skip => transit(item, QueuePhase::Skipped),
-            HitlRespondAction::Replan => transit(item, QueuePhase::Failed),
+            HitlRespondAction::Replan => {
+                let new_replan_count = item.replan_count + 1;
+
+                if new_replan_count > Self::MAX_REPLAN_COUNT {
+                    tracing::warn!(
+                        work_id,
+                        replan_count = new_replan_count,
+                        max = Self::MAX_REPLAN_COUNT,
+                        "replan limit exceeded, transitioning to Failed"
+                    );
+                    item.replan_count = new_replan_count;
+                    return transit(item, QueuePhase::Failed);
+                }
+
+                // Capture metadata before mutating the item for the new HITL item.
+                let failure_reason = item
+                    .hitl_notes
+                    .clone()
+                    .unwrap_or_else(|| "unknown failure".to_string());
+                let source_id = item.source_id.clone();
+                let workspace_id = item.workspace_id.clone();
+                let state = item.state.clone();
+
+                // Roll back item to Pending with incremented replan_count.
+                item.replan_count = new_replan_count;
+                transit(item, QueuePhase::Pending)?;
+
+                // Create a new HITL item for spec modification proposal.
+                let replan_work_id = format!("{work_id}:replan-{new_replan_count}");
+                let mut replan_item =
+                    QueueItem::new(replan_work_id, source_id, workspace_id, state);
+                // The replan item starts at Pending and moves to Hitl to await
+                // human review of the Claw agent's spec modification proposal.
+                transit(&mut replan_item, QueuePhase::Ready)?;
+                transit(&mut replan_item, QueuePhase::Running)?;
+                transit(&mut replan_item, QueuePhase::Completed)?;
+                transit(&mut replan_item, QueuePhase::Hitl)?;
+                replan_item.hitl_created_at = Some(Utc::now().to_rfc3339());
+                replan_item.hitl_reason = Some(HitlReason::SpecModificationProposed);
+                replan_item.hitl_notes = Some(format!(
+                    "Claw replan delegation (attempt {new_replan_count}): {failure_reason}"
+                ));
+                replan_item.title = Some(format!(
+                    "spec-modification-proposed (replan #{new_replan_count})"
+                ));
+                self.queue.push_back(replan_item);
+
+                tracing::info!(
+                    work_id,
+                    replan_count = new_replan_count,
+                    "replan: item rolled back to Pending, spec modification HITL item created"
+                );
+
+                Ok(())
+            }
         }
     }
 
@@ -2778,6 +2840,143 @@ sources:
                 .worktree_mgr
                 .lookup_preserved("github:org/repo#1")
                 .is_none()
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // respond_hitl replan tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn respond_hitl_replan_rolls_back_to_pending_and_creates_hitl_item() {
+        let tmp = TempDir::new().unwrap();
+        let source = MockDataSource::new("github");
+        let mut daemon = setup_daemon(&tmp, source, vec![]);
+
+        let mut item = test_item("s1", "analyze");
+        item.phase = QueuePhase::Hitl;
+        item.hitl_notes = Some("original failure reason".into());
+        daemon.push_item(item);
+
+        let result = daemon.respond_hitl(
+            "s1:analyze",
+            HitlRespondAction::Replan,
+            Some("reviewer".into()),
+            None,
+        );
+        assert!(result.is_ok());
+
+        // Original item should be rolled back to Pending with replan_count = 1.
+        let original = daemon.get_item("s1:analyze").unwrap();
+        assert_eq!(original.phase, QueuePhase::Pending);
+        assert_eq!(original.replan_count, 1);
+
+        // A new HITL item should have been created for spec modification.
+        let replan_item = daemon.get_item("s1:analyze:replan-1").unwrap();
+        assert_eq!(replan_item.phase, QueuePhase::Hitl);
+        assert_eq!(
+            replan_item.hitl_reason,
+            Some(HitlReason::SpecModificationProposed)
+        );
+        assert!(
+            replan_item
+                .hitl_notes
+                .as_ref()
+                .unwrap()
+                .contains("original failure reason")
+        );
+        assert!(
+            replan_item
+                .title
+                .as_ref()
+                .unwrap()
+                .contains("spec-modification-proposed")
+        );
+    }
+
+    #[test]
+    fn respond_hitl_replan_increments_count_on_successive_replans() {
+        let tmp = TempDir::new().unwrap();
+        let source = MockDataSource::new("github");
+        let mut daemon = setup_daemon(&tmp, source, vec![]);
+
+        let mut item = test_item("s1", "analyze");
+        item.phase = QueuePhase::Hitl;
+        item.replan_count = 1; // Already replanned once.
+        daemon.push_item(item);
+
+        let result = daemon.respond_hitl(
+            "s1:analyze",
+            HitlRespondAction::Replan,
+            None,
+            Some("second failure".into()),
+        );
+        assert!(result.is_ok());
+
+        let original = daemon.get_item("s1:analyze").unwrap();
+        assert_eq!(original.phase, QueuePhase::Pending);
+        assert_eq!(original.replan_count, 2);
+
+        let replan_item = daemon.get_item("s1:analyze:replan-2").unwrap();
+        assert_eq!(replan_item.phase, QueuePhase::Hitl);
+    }
+
+    #[test]
+    fn respond_hitl_replan_exceeds_limit_transitions_to_failed() {
+        let tmp = TempDir::new().unwrap();
+        let source = MockDataSource::new("github");
+        let mut daemon = setup_daemon(&tmp, source, vec![]);
+
+        let mut item = test_item("s1", "analyze");
+        item.phase = QueuePhase::Hitl;
+        item.replan_count = 3; // Already at max.
+        daemon.push_item(item);
+
+        let result = daemon.respond_hitl("s1:analyze", HitlRespondAction::Replan, None, None);
+        assert!(result.is_ok());
+
+        // Should transition to Failed, not Pending.
+        let original = daemon.get_item("s1:analyze").unwrap();
+        assert_eq!(original.phase, QueuePhase::Failed);
+        assert_eq!(original.replan_count, 4);
+
+        // No replan HITL item should be created.
+        assert!(daemon.get_item("s1:analyze:replan-4").is_none());
+    }
+
+    #[test]
+    fn respond_hitl_replan_requires_hitl_phase() {
+        let tmp = TempDir::new().unwrap();
+        let source = MockDataSource::new("github");
+        let mut daemon = setup_daemon(&tmp, source, vec![]);
+
+        // Item is in Pending, not Hitl.
+        daemon.push_item(test_item("s1", "analyze"));
+
+        let result = daemon.respond_hitl("s1:analyze", HitlRespondAction::Replan, None, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn respond_hitl_done_still_works() {
+        let tmp = TempDir::new().unwrap();
+        let source = MockDataSource::new("github");
+        let mut daemon = setup_daemon(&tmp, source, vec![]);
+
+        let mut item = test_item("s1", "analyze");
+        item.phase = QueuePhase::Hitl;
+        daemon.push_item(item);
+
+        let result = daemon.respond_hitl(
+            "s1:analyze",
+            HitlRespondAction::Done,
+            Some("reviewer".into()),
+            None,
+        );
+        assert!(result.is_ok());
+        assert_eq!(
+            daemon.get_item("s1:analyze").unwrap().phase,
+            QueuePhase::Done
         );
     }
 }

--- a/crates/belt-infra/src/db.rs
+++ b/crates/belt-infra/src/db.rs
@@ -213,7 +213,8 @@ impl Database {
                 hitl_notes       TEXT,
                 hitl_reason          TEXT,
                 hitl_timeout_at      TEXT,
-                hitl_terminal_action TEXT
+                hitl_terminal_action TEXT,
+                replan_count         INTEGER NOT NULL DEFAULT 0
             );
 
             CREATE TABLE IF NOT EXISTS history (
@@ -327,8 +328,8 @@ impl Database {
             .lock()
             .map_err(|e| BeltError::Database(e.to_string()))?;
         conn.execute(
-            "INSERT INTO queue_items (work_id, source_id, workspace_id, state, phase, title, created_at, updated_at, hitl_created_at, hitl_respondent, hitl_notes, hitl_reason, hitl_timeout_at, hitl_terminal_action)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+            "INSERT INTO queue_items (work_id, source_id, workspace_id, state, phase, title, created_at, updated_at, hitl_created_at, hitl_respondent, hitl_notes, hitl_reason, hitl_timeout_at, hitl_terminal_action, replan_count)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
             params![
                 item.work_id,
                 item.source_id,
@@ -344,6 +345,7 @@ impl Database {
                 item.hitl_reason.map(|r| r.to_string()),
                 item.hitl_timeout_at,
                 item.hitl_terminal_action,
+                item.replan_count,
             ],
         )
         .map_err(|e| BeltError::Database(e.to_string()))?;
@@ -467,7 +469,7 @@ impl Database {
             .map_err(|e| BeltError::Database(e.to_string()))?;
         let mut stmt = conn
             .prepare(
-                "SELECT work_id, source_id, workspace_id, state, phase, title, created_at, updated_at, hitl_created_at, hitl_respondent, hitl_notes, hitl_reason, hitl_timeout_at, hitl_terminal_action FROM queue_items WHERE phase = 'hitl' AND hitl_timeout_at IS NOT NULL",
+                "SELECT work_id, source_id, workspace_id, state, phase, title, created_at, updated_at, hitl_created_at, hitl_respondent, hitl_notes, hitl_reason, hitl_timeout_at, hitl_terminal_action, replan_count FROM queue_items WHERE phase = 'hitl' AND hitl_timeout_at IS NOT NULL",
             )
             .map_err(|e| BeltError::Database(e.to_string()))?;
         let items = stmt
@@ -488,7 +490,7 @@ impl Database {
             .lock()
             .map_err(|e| BeltError::Database(e.to_string()))?;
         conn.query_row(
-            "SELECT work_id, source_id, workspace_id, state, phase, title, created_at, updated_at, hitl_created_at, hitl_respondent, hitl_notes, hitl_reason, hitl_timeout_at, hitl_terminal_action
+            "SELECT work_id, source_id, workspace_id, state, phase, title, created_at, updated_at, hitl_created_at, hitl_respondent, hitl_notes, hitl_reason, hitl_timeout_at, hitl_terminal_action, replan_count
                  FROM queue_items WHERE work_id = ?1",
             params![work_id],
             |row| Ok(row_to_queue_item(row)),
@@ -512,7 +514,7 @@ impl Database {
             .lock()
             .map_err(|e| BeltError::Database(e.to_string()))?;
         let mut sql = String::from(
-            "SELECT work_id, source_id, workspace_id, state, phase, title, created_at, updated_at, hitl_created_at, hitl_respondent, hitl_notes, hitl_reason, hitl_timeout_at, hitl_terminal_action FROM queue_items WHERE 1=1",
+            "SELECT work_id, source_id, workspace_id, state, phase, title, created_at, updated_at, hitl_created_at, hitl_respondent, hitl_notes, hitl_reason, hitl_timeout_at, hitl_terminal_action, replan_count FROM queue_items WHERE 1=1",
         );
         let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
 
@@ -1831,6 +1833,10 @@ fn row_to_queue_item(row: &rusqlite::Row<'_>) -> Result<QueueItem, BeltError> {
             "timeout" => Ok(belt_core::queue::HitlReason::Timeout),
             "manual_escalation" => Ok(belt_core::queue::HitlReason::ManualEscalation),
             "spec_conflict" => Ok(belt_core::queue::HitlReason::SpecConflict),
+            "spec_completion_review" => Ok(belt_core::queue::HitlReason::SpecCompletionReview),
+            "spec_modification_proposed" => {
+                Ok(belt_core::queue::HitlReason::SpecModificationProposed)
+            }
             other => Err(BeltError::Database(format!("unknown hitl_reason: {other}"))),
         })
         .transpose()?;
@@ -1859,6 +1865,7 @@ fn row_to_queue_item(row: &rusqlite::Row<'_>) -> Result<QueueItem, BeltError> {
         worktree_preserved: false,
         // previous_worktree_path is transient (in-memory only, not persisted to DB).
         previous_worktree_path: None,
+        replan_count: row.get::<_, u32>(14).unwrap_or(0),
     })
 }
 
@@ -1888,6 +1895,7 @@ mod tests {
             hitl_terminal_action: None,
             worktree_preserved: false,
             previous_worktree_path: None,
+            replan_count: 0,
         }
     }
 

--- a/crates/belt-infra/src/sources/github.rs
+++ b/crates/belt-infra/src/sources/github.rs
@@ -417,6 +417,7 @@ impl DataSource for GitHubDataSource {
                                 hitl_terminal_action: None,
                                 worktree_preserved: false,
                                 previous_worktree_path: None,
+                                replan_count: 0,
                             });
                         }
                     }


### PR DESCRIPTION
## Summary

Autopilot 자동 구현

Closes #185

## Changes

Implements HITL replan action to delegate spec modification to Claw. The implementation:
- Rolls back failed items to Pending state with replan_count increment
- Invokes Claw agent to generate spec modification proposals
- Creates HITL items for human review of spec changes
- Enforces replan_count limit (max 3) to prevent infinite loops