### PR TITLE
feat(agent): inject Claw rules system prompt into agent LLM session

### DIFF
--- a/crates/belt-cli/src/agent.rs
+++ b/crates/belt-cli/src/agent.rs
@@ -65,6 +65,42 @@ fn resolve_rules_dir(config: &WorkspaceConfig) -> Option<PathBuf> {
     None
 }
 
+/// Default maximum conversation turns per session.
+const DEFAULT_MAX_CONVERSATION_TURNS: u32 = 10;
+
+/// Build the built-in Claw rules system prompt.
+///
+/// Generates a system prompt section containing core agent behavioral rules:
+/// - Conversation turn limit
+/// - Response format guidelines (JSON/markdown)
+/// - Error handling and retry strategy
+///
+/// The `max_turns` parameter overrides the default turn limit when provided
+/// via `ClawConfig.max_conversation_turns`.
+fn build_claw_rules_prompt(max_turns: Option<u32>) -> String {
+    let turns = max_turns.unwrap_or(DEFAULT_MAX_CONVERSATION_TURNS);
+    format!(
+        r#"# Claw Agent Rules
+
+## Conversation Turn Limit
+- Maximum conversation turns per session: {turns}
+- If the task cannot be completed within the turn limit, summarize progress and remaining steps before stopping.
+- Each prompt-response pair counts as one turn.
+
+## Response Format
+- Use JSON for structured data output (status reports, action results, diagnostics).
+- Use Markdown for human-readable explanations, plans, and summaries.
+- When both are appropriate, prefer JSON wrapped in a markdown code block.
+- Always include a top-level "status" field in JSON responses ("success", "error", "partial").
+
+## Error Handling
+- On transient errors (network, timeout), retry up to 3 times with exponential backoff.
+- On permanent errors (invalid input, missing resource), report immediately without retry.
+- Always include error context: what was attempted, what failed, and suggested next steps.
+- Never silently swallow errors; surface them in the response."#
+    )
+}
+
 /// Load all `.md` rule files from a directory into a single system prompt.
 ///
 /// Files are sorted by name for deterministic ordering and concatenated
@@ -777,6 +813,121 @@ runtime:
         assert!(prompt.find("Safety first").unwrap() < prompt.find("Use Rust idioms").unwrap());
     }
 
+    // ---- build_claw_rules_prompt ----
+
+    #[test]
+    fn build_claw_rules_prompt_uses_default_turn_limit() {
+        let prompt = build_claw_rules_prompt(None);
+        assert!(prompt.contains("Maximum conversation turns per session: 10"));
+    }
+
+    #[test]
+    fn build_claw_rules_prompt_uses_custom_turn_limit() {
+        let prompt = build_claw_rules_prompt(Some(25));
+        assert!(prompt.contains("Maximum conversation turns per session: 25"));
+        assert!(!prompt.contains("session: 10"));
+    }
+
+    #[test]
+    fn build_claw_rules_prompt_contains_response_format_section() {
+        let prompt = build_claw_rules_prompt(None);
+        assert!(prompt.contains("## Response Format"));
+        assert!(prompt.contains("JSON"));
+        assert!(prompt.contains("Markdown"));
+    }
+
+    #[test]
+    fn build_claw_rules_prompt_contains_error_handling_section() {
+        let prompt = build_claw_rules_prompt(None);
+        assert!(prompt.contains("## Error Handling"));
+        assert!(prompt.contains("retry up to 3 times"));
+        assert!(prompt.contains("exponential backoff"));
+    }
+
+    #[test]
+    fn build_claw_rules_prompt_contains_all_sections() {
+        let prompt = build_claw_rules_prompt(None);
+        assert!(prompt.contains("# Claw Agent Rules"));
+        assert!(prompt.contains("## Conversation Turn Limit"));
+        assert!(prompt.contains("## Response Format"));
+        assert!(prompt.contains("## Error Handling"));
+    }
+
+    // ---- claw rules integration with system prompt ----
+
+    #[test]
+    fn claw_rules_injected_without_file_rules() {
+        let config = empty_workspace();
+
+        // Simulate run_agent logic: no rules dir, so only built-in claw rules.
+        let max_turns = config
+            .claw_config
+            .as_ref()
+            .and_then(|c| c.max_conversation_turns);
+        let claw_rules = build_claw_rules_prompt(max_turns);
+
+        let working_dir = std::env::current_dir().unwrap();
+        let env = ActionEnv::new("test-agent", &working_dir).with_system_prompt(claw_rules);
+
+        let prompt = env.system_prompt.unwrap();
+        assert!(prompt.contains("# Claw Agent Rules"));
+        assert!(prompt.contains("Maximum conversation turns per session: 10"));
+    }
+
+    #[test]
+    fn claw_rules_combined_with_file_rules() {
+        let tmp = tempfile::tempdir().unwrap();
+        let rules_dir = tmp.path().join("rules");
+        std::fs::create_dir_all(&rules_dir).unwrap();
+        std::fs::write(rules_dir.join("custom.md"), "Custom workspace rule").unwrap();
+
+        let mut config = empty_workspace();
+        config.claw_config = Some(belt_core::workspace::ClawConfig {
+            rules_path: Some(rules_dir.to_string_lossy().to_string()),
+            max_conversation_turns: Some(5),
+            ..Default::default()
+        });
+
+        // Simulate the same combination logic as run_agent.
+        let max_turns = config
+            .claw_config
+            .as_ref()
+            .and_then(|c| c.max_conversation_turns);
+        let claw_rules = build_claw_rules_prompt(max_turns);
+
+        let resolved = resolve_rules_dir(&config).expect("should resolve rules dir");
+        let file_rules = load_rules_from_dir(&resolved).unwrap();
+
+        let system_prompt = match file_rules {
+            Some(file_prompt) => format!("{claw_rules}\n\n---\n\n{file_prompt}"),
+            None => claw_rules,
+        };
+
+        // Claw rules come first.
+        assert!(system_prompt.contains("# Claw Agent Rules"));
+        assert!(system_prompt.contains("Maximum conversation turns per session: 5"));
+        // File rules follow after separator.
+        assert!(system_prompt.contains("---"));
+        assert!(system_prompt.contains("Custom workspace rule"));
+        // Verify ordering: claw rules before file rules.
+        let claw_pos = system_prompt.find("# Claw Agent Rules").unwrap();
+        let file_pos = system_prompt.find("Custom workspace rule").unwrap();
+        assert!(claw_pos < file_pos);
+    }
+
+    #[test]
+    fn claw_config_max_turns_defaults_to_none() {
+        let config = empty_workspace();
+        let max_turns = config
+            .claw_config
+            .as_ref()
+            .and_then(|c| c.max_conversation_turns);
+        assert!(max_turns.is_none());
+        // Which results in the default of 10.
+        let prompt = build_claw_rules_prompt(max_turns);
+        assert!(prompt.contains("session: 10"));
+    }
+
     /// RAII guard for setting environment variables in tests.
     /// Restores (or removes) the variable on drop.
     struct EnvGuard {
@@ -845,22 +996,31 @@ pub async fn run_agent(
     // Use current directory as working directory.
     let working_dir = std::env::current_dir().context("failed to determine current directory")?;
 
-    // Resolve workspace rules and inject as system prompt.
+    // Build the system prompt by combining built-in Claw rules with
+    // workspace-specific rules loaded from the rules directory.
     let mut env = ActionEnv::new("cli-agent", &working_dir);
-    if let Some(rules_dir) = resolve_rules_dir(&config) {
+
+    let max_turns = config
+        .claw_config
+        .as_ref()
+        .and_then(|c| c.max_conversation_turns);
+    let claw_rules = build_claw_rules_prompt(max_turns);
+
+    let file_rules = if let Some(rules_dir) = resolve_rules_dir(&config) {
         match load_rules_from_dir(&rules_dir) {
-            Ok(Some(system_prompt)) => {
+            Ok(Some(rules)) => {
                 tracing::info!(
                     rules_dir = %rules_dir.display(),
-                    "loaded workspace rules as system prompt"
+                    "loaded workspace rules from directory"
                 );
-                env = env.with_system_prompt(system_prompt);
+                Some(rules)
             }
             Ok(None) => {
                 tracing::debug!(
                     rules_dir = %rules_dir.display(),
                     "rules directory exists but contains no .md files"
                 );
+                None
             }
             Err(e) => {
                 tracing::warn!(
@@ -868,9 +1028,18 @@ pub async fn run_agent(
                     error = %e,
                     "failed to load workspace rules, continuing without"
                 );
+                None
             }
         }
-    }
+    } else {
+        None
+    };
+
+    let system_prompt = match file_rules {
+        Some(file_prompt) => format!("{claw_rules}\n\n---\n\n{file_prompt}"),
+        None => claw_rules,
+    };
+    env = env.with_system_prompt(system_prompt);
 
     tracing::info!(
         workspace = config.name,

--- a/crates/belt-core/src/workspace.rs
+++ b/crates/belt-core/src/workspace.rs
@@ -43,6 +43,12 @@ pub struct ClawConfig {
     /// as context into the agent runtime's system prompt.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rules_path: Option<String>,
+    /// Maximum number of conversation turns allowed per session.
+    ///
+    /// Defaults to 10 when not set. Injected into the system prompt
+    /// to guide the LLM's behavior.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_conversation_turns: Option<u32>,
 }
 
 /// DataSource별 설정.
@@ -348,5 +354,35 @@ claw_config:
         let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
         let claw = config.claw_config.unwrap();
         assert!(claw.rules_path.is_none());
+    }
+
+    #[test]
+    fn claw_config_parses_max_conversation_turns() {
+        let yaml = r#"
+name: with-turns
+sources:
+  github:
+    url: https://github.com/org/repo
+claw_config:
+  max_conversation_turns: 25
+"#;
+        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        let claw = config.claw_config.unwrap();
+        assert_eq!(claw.max_conversation_turns, Some(25));
+    }
+
+    #[test]
+    fn claw_config_max_conversation_turns_defaults_to_none() {
+        let yaml = r#"
+name: no-turns
+sources:
+  github:
+    url: https://github.com/org/repo
+claw_config:
+  auto_approve: false
+"#;
+        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        let claw = config.claw_config.unwrap();
+        assert!(claw.max_conversation_turns.is_none());
     }
 }


### PR DESCRIPTION
## Summary

Autopilot 자동 구현

Closes #375

## Changes

Inject Claw rules system prompt into agent LLM session to enable rule-based constraint enforcement during autonomous agent execution.