### PR TITLE
feat(cli): implement spec decomposition with automatic GitHub issue creation

### DIFF
--- a/crates/belt-cli/src/main.rs
+++ b/crates/belt-cli/src/main.rs
@@ -1732,6 +1732,91 @@ async fn refine_criteria_with_llm(
     }
 }
 
+/// Decompose a spec into independent sub-issues using an LLM.
+///
+/// Sends the spec content and acceptance criteria to the LLM and asks it to
+/// produce structured JSON output with title, description, and acceptance
+/// criteria for each proposed sub-issue. Falls back to `None` if the LLM is
+/// unavailable or returns unparseable output, allowing the caller to use the
+/// simpler `build_decomposed_issues` path.
+async fn decompose_spec_with_llm(
+    criteria: &[String],
+    spec_name: &str,
+    spec_content: &str,
+) -> Option<Vec<belt_core::spec::LlmDecomposedIssue>> {
+    let runtime = belt_infra::runtimes::claude::ClaudeRuntime::new(None);
+
+    let numbered_criteria: String = criteria
+        .iter()
+        .enumerate()
+        .map(|(i, c)| format!("{}. {}", i + 1, c))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let prompt = format!(
+        "You are a technical project manager decomposing a spec into independent GitHub issues.\n\n\
+         Spec name: {spec_name}\n\n\
+         Spec content:\n{spec_summary}\n\n\
+         Acceptance criteria:\n{numbered_criteria}\n\n\
+         Decompose this spec into independent, implementable GitHub issues. \
+         Each issue should be self-contained and map to one or more acceptance criteria.\n\n\
+         Output ONLY a JSON array of objects with these fields:\n\
+         - \"title\": concise issue title (string)\n\
+         - \"description\": detailed markdown body with context, implementation hints, \
+           affected files/modules, and verification steps (string)\n\
+         - \"acceptance_criteria\": specific testable acceptance criteria for this sub-issue \
+           (array of strings)\n\n\
+         Rules:\n\
+         - Every original acceptance criterion must be covered by at least one sub-issue\n\
+         - Each sub-issue should be independently implementable\n\
+         - Keep titles under 80 characters\n\
+         - Include enough detail in descriptions for a developer to start working immediately\n\n\
+         Output ONLY the JSON array, no wrapping object or markdown fences.",
+        spec_summary = &spec_content[..spec_content.len().min(3000)],
+    );
+
+    let request = belt_core::runtime::RuntimeRequest {
+        working_dir: std::env::current_dir().unwrap_or_default(),
+        prompt,
+        model: None,
+        system_prompt: None,
+        session_id: None,
+        structured_output: None,
+    };
+
+    let response = runtime.invoke(request).await;
+    if !response.success() {
+        eprintln!(
+            "info: LLM decomposition unavailable, falling back to criteria-based decomposition"
+        );
+        return None;
+    }
+
+    let stdout = response.stdout.trim();
+    let json_str = stdout
+        .strip_prefix("```json")
+        .or_else(|| stdout.strip_prefix("```"))
+        .unwrap_or(stdout)
+        .strip_suffix("```")
+        .unwrap_or(stdout)
+        .trim();
+
+    match serde_json::from_str::<Vec<belt_core::spec::LlmDecomposedIssue>>(json_str) {
+        Ok(issues) if !issues.is_empty() => {
+            eprintln!("info: LLM decomposed spec into {} sub-issues", issues.len());
+            Some(issues)
+        }
+        Ok(_) => {
+            eprintln!("info: LLM returned empty decomposition, falling back");
+            None
+        }
+        Err(e) => {
+            eprintln!("info: could not parse LLM decomposition ({e}), falling back");
+            None
+        }
+    }
+}
+
 /// Create a GitHub issue via the `gh` CLI and return the issue URL on success.
 fn create_github_issue(title: &str, body: &str) -> Option<String> {
     create_github_issue_with_labels(title, body, &["autopilot:ready"])
@@ -2363,18 +2448,29 @@ async fn main() -> anyhow::Result<()> {
                     {
                         let parent_number = extract_issue_number(parent);
 
-                        // Step 2: LLM refinement of acceptance criteria.
-                        // Attempt to use the default runtime to decompose each
-                        // criterion into a more detailed, actionable description.
-                        let refined =
-                            refine_criteria_with_llm(&criteria, &spec.name, &spec.content).await;
+                        // Step 2: LLM-based structured decomposition.
+                        // First try full structured decomposition (title + description +
+                        // acceptance_criteria). If unavailable, fall back to simple
+                        // criteria refinement.
+                        let llm_decomposed =
+                            decompose_spec_with_llm(&criteria, &spec.name, &spec.content).await;
 
-                        // Build structured issue proposals.
-                        let proposed_issues = belt_core::spec::build_decomposed_issues(
-                            &criteria,
-                            refined.as_deref(),
-                            parent_number.as_deref(),
-                        );
+                        let proposed_issues = if let Some(ref llm_issues) = llm_decomposed {
+                            belt_core::spec::build_decomposed_issues_from_llm(
+                                llm_issues,
+                                parent_number.as_deref(),
+                            )
+                        } else {
+                            // Fallback: refine criteria text only.
+                            let refined =
+                                refine_criteria_with_llm(&criteria, &spec.name, &spec.content)
+                                    .await;
+                            belt_core::spec::build_decomposed_issues(
+                                &criteria,
+                                refined.as_deref(),
+                                parent_number.as_deref(),
+                            )
+                        };
 
                         // Step 3: User confirmation (unless --yes).
                         let confirmed = if yes {

--- a/crates/belt-core/src/spec.rs
+++ b/crates/belt-core/src/spec.rs
@@ -435,6 +435,68 @@ pub struct DecomposedIssue {
     pub criterion: String,
 }
 
+/// Structured LLM decomposition output for a single sub-issue.
+///
+/// The LLM produces this structure when decomposing a spec into independent
+/// issues. Each entry includes a concise title, detailed description with
+/// implementation hints, and specific acceptance criteria for verification.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LlmDecomposedIssue {
+    /// Concise issue title (e.g. "Add OAuth2 token refresh endpoint").
+    pub title: String,
+    /// Detailed issue description in markdown with context and implementation hints.
+    pub description: String,
+    /// Specific acceptance criteria for this sub-issue.
+    pub acceptance_criteria: Vec<String>,
+}
+
+/// Build [`DecomposedIssue`] proposals from LLM-structured decomposition output.
+///
+/// Each `LlmDecomposedIssue` is converted into a `DecomposedIssue` with a
+/// formatted body that includes the description, acceptance criteria, and a
+/// back-reference to the parent spec issue.
+pub fn build_decomposed_issues_from_llm(
+    llm_issues: &[LlmDecomposedIssue],
+    parent_number: Option<&str>,
+) -> Vec<DecomposedIssue> {
+    llm_issues
+        .iter()
+        .enumerate()
+        .map(|(i, issue)| {
+            let idx = i + 1;
+            let parent_ref = parent_number.unwrap_or("?");
+            let title = format!("[sub] #{parent_ref} AC{idx}: {}", issue.title);
+
+            let parent_link = parent_number
+                .map(|n| format!("Parent: #{n}"))
+                .unwrap_or_else(|| "Parent: (pending)".to_string());
+
+            let ac_section = if issue.acceptance_criteria.is_empty() {
+                String::new()
+            } else {
+                let items: Vec<String> = issue
+                    .acceptance_criteria
+                    .iter()
+                    .map(|ac| format!("- [ ] {ac}"))
+                    .collect();
+                format!("\n\n## Acceptance Criteria\n\n{}", items.join("\n"))
+            };
+
+            let body = format!(
+                "{parent_link}\n\n## Description\n\n{}{}",
+                issue.description, ac_section
+            );
+
+            DecomposedIssue {
+                index: idx,
+                title,
+                body,
+                criterion: issue.title.clone(),
+            }
+        })
+        .collect()
+}
+
 /// Build [`DecomposedIssue`] proposals from raw acceptance criteria and optional
 /// LLM-refined descriptions.
 ///
@@ -1175,5 +1237,110 @@ mod tests {
         assert!(preview.contains("Proposed 2 child issue(s):"));
         assert!(preview.contains("AC1:"));
         assert!(preview.contains("AC2:"));
+    }
+
+    #[test]
+    fn llm_decomposed_issue_serde_roundtrip() {
+        let issue = LlmDecomposedIssue {
+            title: "Add OAuth2 token refresh".to_string(),
+            description: "Implement token refresh endpoint.".to_string(),
+            acceptance_criteria: vec![
+                "Refresh token is validated".to_string(),
+                "New access token is returned".to_string(),
+            ],
+        };
+        let json = serde_json::to_string(&issue).unwrap();
+        let parsed: LlmDecomposedIssue = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, issue);
+    }
+
+    #[test]
+    fn llm_decomposed_issue_array_parse() {
+        let json = r#"[
+            {
+                "title": "Issue one",
+                "description": "Desc one",
+                "acceptance_criteria": ["AC 1a", "AC 1b"]
+            },
+            {
+                "title": "Issue two",
+                "description": "Desc two",
+                "acceptance_criteria": ["AC 2a"]
+            }
+        ]"#;
+        let issues: Vec<LlmDecomposedIssue> = serde_json::from_str(json).unwrap();
+        assert_eq!(issues.len(), 2);
+        assert_eq!(issues[0].title, "Issue one");
+        assert_eq!(issues[1].acceptance_criteria.len(), 1);
+    }
+
+    #[test]
+    fn build_decomposed_issues_from_llm_basic() {
+        let llm_issues = vec![
+            LlmDecomposedIssue {
+                title: "Add login endpoint".to_string(),
+                description: "Implement POST /login with JWT.".to_string(),
+                acceptance_criteria: vec![
+                    "Returns 200 with valid credentials".to_string(),
+                    "Returns 401 with invalid credentials".to_string(),
+                ],
+            },
+            LlmDecomposedIssue {
+                title: "Add logout endpoint".to_string(),
+                description: "Implement POST /logout.".to_string(),
+                acceptance_criteria: vec!["Invalidates session".to_string()],
+            },
+        ];
+
+        let issues = build_decomposed_issues_from_llm(&llm_issues, Some("100"));
+        assert_eq!(issues.len(), 2);
+
+        // Check first issue
+        assert_eq!(issues[0].index, 1);
+        assert!(issues[0].title.contains("#100"));
+        assert!(issues[0].title.contains("AC1"));
+        assert!(issues[0].title.contains("Add login endpoint"));
+        assert!(issues[0].body.contains("Parent: #100"));
+        assert!(issues[0].body.contains("## Description"));
+        assert!(issues[0].body.contains("Implement POST /login with JWT."));
+        assert!(issues[0].body.contains("## Acceptance Criteria"));
+        assert!(
+            issues[0]
+                .body
+                .contains("- [ ] Returns 200 with valid credentials")
+        );
+        assert!(
+            issues[0]
+                .body
+                .contains("- [ ] Returns 401 with invalid credentials")
+        );
+        assert_eq!(issues[0].criterion, "Add login endpoint");
+
+        // Check second issue
+        assert_eq!(issues[1].index, 2);
+        assert!(issues[1].title.contains("AC2"));
+        assert!(issues[1].body.contains("Invalidates session"));
+    }
+
+    #[test]
+    fn build_decomposed_issues_from_llm_no_parent() {
+        let llm_issues = vec![LlmDecomposedIssue {
+            title: "Setup CI".to_string(),
+            description: "Configure GitHub Actions.".to_string(),
+            acceptance_criteria: vec![],
+        }];
+
+        let issues = build_decomposed_issues_from_llm(&llm_issues, None);
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].title.contains("#?"));
+        assert!(issues[0].body.contains("Parent: (pending)"));
+        // No acceptance criteria section when empty
+        assert!(!issues[0].body.contains("## Acceptance Criteria"));
+    }
+
+    #[test]
+    fn build_decomposed_issues_from_llm_empty_input() {
+        let issues = build_decomposed_issues_from_llm(&[], Some("50"));
+        assert!(issues.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Implements LLM-based spec decomposition with structured GitHub issue creation for CLI.

Closes #410

## Changes

- Add spec decomposition logic to belt-core with structured issue data models
- Implement automatic GitHub issue creation from decomposed specs
- Integrate with existing /spec slash command plugin
- Add comprehensive tests for spec decomposition workflow