### PR TITLE
feat(cli): auto-seed per-workspace crons on workspace registration

### DIFF
--- a/crates/belt-daemon/src/cron.rs
+++ b/crates/belt-daemon/src/cron.rs
@@ -3009,12 +3009,13 @@ pub fn load_custom_jobs(engine: &mut CronEngine, db: &Arc<Database>) {
 
 /// Seed built-in cron jobs for a specific workspace.
 ///
-/// Creates workspace-scoped instances of the standard jobs with the
-/// intervals specified in the issue requirements:
+/// Creates workspace-scoped instances of the standard jobs:
 /// - `HitlTimeoutJob` — every 1 hour
 /// - `DailyReportJob` — every 24 hours
 /// - `LogCleanupJob` — every 6 hours
-/// - `EvaluateJob` — every 60 seconds
+/// - `EvaluateJob` — every 6 hours
+/// - `GapDetectionJob` — every 12 hours
+/// - `KnowledgeExtractionJob` — every 24 hours
 ///
 /// The `deps` parameter provides the shared dependencies (DB, worktree manager,
 /// belt home, workspace name) used to initialise each job handler.
@@ -3059,7 +3060,7 @@ pub fn seed_workspace_crons(engine: &mut CronEngine, workspace: &str, deps: Buil
 
     engine.register(CronJobDef {
         name: format!("{ws}:evaluate"),
-        schedule: CronSchedule::Interval(Duration::from_secs(60)),
+        schedule: CronSchedule::Interval(Duration::from_secs(21600)), // every 6 hours
         workspace: Some(ws.clone()),
         enabled: true,
         last_run_at: None,
@@ -3067,8 +3068,20 @@ pub fn seed_workspace_crons(engine: &mut CronEngine, workspace: &str, deps: Buil
     });
 
     engine.register(CronJobDef {
+        name: format!("{ws}:gap_detection"),
+        schedule: CronSchedule::Interval(Duration::from_secs(43200)), // every 12 hours
+        workspace: Some(ws.clone()),
+        enabled: true,
+        last_run_at: None,
+        handler: Box::new(GapDetectionJob::new(
+            Arc::clone(&deps.db),
+            deps.workspace_root.clone(),
+        )),
+    });
+
+    engine.register(CronJobDef {
         name: format!("{ws}:knowledge_extraction"),
-        schedule: CronSchedule::Interval(Duration::from_secs(3600)),
+        schedule: CronSchedule::Interval(Duration::from_secs(86400)), // every 24 hours
         workspace: Some(ws.clone()),
         enabled: true,
         last_run_at: None,
@@ -4064,11 +4077,11 @@ mod tests {
     // -- seed_workspace_crons tests --
 
     #[test]
-    fn seed_workspace_crons_registers_five_jobs() {
+    fn seed_workspace_crons_registers_six_jobs() {
         let mut engine = CronEngine::new();
         let deps = make_test_deps();
         seed_workspace_crons(&mut engine, "my-project", deps);
-        assert_eq!(engine.job_count(), 5);
+        assert_eq!(engine.job_count(), 6);
     }
 
     #[test]
@@ -4083,6 +4096,7 @@ mod tests {
         assert!(names.contains(&"auth:daily_report"));
         assert!(names.contains(&"auth:log_cleanup"));
         assert!(names.contains(&"auth:evaluate"));
+        assert!(names.contains(&"auth:gap_detection"));
         assert!(names.contains(&"auth:knowledge_extraction"));
     }
 
@@ -4104,7 +4118,7 @@ mod tests {
         let deps2 = make_test_deps();
         seed_workspace_crons(&mut engine, "alpha", deps1);
         seed_workspace_crons(&mut engine, "beta", deps2);
-        assert_eq!(engine.job_count(), 10);
+        assert_eq!(engine.job_count(), 12);
     }
 
     #[test]
@@ -4114,8 +4128,8 @@ mod tests {
         let deps2 = make_test_deps();
         seed_workspace_crons(&mut engine, "ws", deps1);
         seed_workspace_crons(&mut engine, "ws", deps2);
-        // register() replaces by name, so should still be 5.
-        assert_eq!(engine.job_count(), 5);
+        // register() replaces by name, so should still be 6.
+        assert_eq!(engine.job_count(), 6);
     }
 
     // -- resolve_workspace_terminal_phase unit tests --

--- a/crates/belt-infra/src/onboarding.rs
+++ b/crates/belt-infra/src/onboarding.rs
@@ -37,9 +37,9 @@ const WORKSPACE_CRON_SEEDS: &[(&str, &str)] = &[
     ("hitl_timeout", "*/5 * * * *"),
     ("daily_report", "0 6 * * *"),
     ("log_cleanup", "0 0 * * *"),
-    ("evaluate", "*/1 * * * *"),
-    ("gap_detection", "*/30 * * * *"),
-    ("knowledge_extraction", "0 2 * * *"),
+    ("evaluate", "0 */6 * * *"),
+    ("gap_detection", "0 */12 * * *"),
+    ("knowledge_extraction", "0 0 * * *"),
 ];
 
 /// Execute the full onboarding flow for a workspace.
@@ -396,14 +396,14 @@ sources:
         );
         assert_eq!(job_map.get("test-project:daily_report"), Some(&"0 6 * * *"));
         assert_eq!(job_map.get("test-project:log_cleanup"), Some(&"0 0 * * *"));
-        assert_eq!(job_map.get("test-project:evaluate"), Some(&"*/1 * * * *"));
+        assert_eq!(job_map.get("test-project:evaluate"), Some(&"0 */6 * * *"));
         assert_eq!(
             job_map.get("test-project:gap_detection"),
-            Some(&"*/30 * * * *")
+            Some(&"0 */12 * * *")
         );
         assert_eq!(
             job_map.get("test-project:knowledge_extraction"),
-            Some(&"0 2 * * *")
+            Some(&"0 0 * * *")
         );
     }
 


### PR DESCRIPTION
## Summary

Autopilot 자동 구현

- Update cron schedules: evaluate (6h), gap_detection (12h), knowledge_extraction (24h)
- Add gap_detection to daemon seed_workspace_crons (was missing from per-workspace seeding)
- Update tests to reflect 6 workspace-scoped cron jobs and new schedules

Closes #413

## Changes

Per-workspace 크론 자동 초기화 구현

🤖 Generated with Claude Code