### PR TITLE
fix(daemon): implement actual LLM evaluation in evaluate cron job

### DIFF
--- a/crates/belt-daemon/src/cron.rs
+++ b/crates/belt-daemon/src/cron.rs
@@ -2515,14 +2515,19 @@ impl CronHandler for EvaluateJob {
             return Ok(());
         }
 
+        // 2. Apply batch size limit to avoid unbounded LLM calls per cycle.
+        let batch_size = crate::evaluator::DEFAULT_EVAL_BATCH_SIZE;
+        let batch_items: Vec<_> = completed_items.into_iter().take(batch_size).collect();
+
         tracing::info!(
-            count = completed_items.len(),
+            count = batch_items.len(),
+            batch_size,
             "EvaluateJob: found completed items for evaluation"
         );
 
-        // 2. Group by workspace to run one evaluator per workspace.
+        // 3. Group by workspace for per-workspace evaluator configuration.
         let mut by_workspace: HashMap<String, Vec<&belt_core::queue::QueueItem>> = HashMap::new();
-        for item in &completed_items {
+        for item in &batch_items {
             by_workspace
                 .entry(item.workspace_id.clone())
                 .or_default()
@@ -2552,10 +2557,10 @@ impl CronHandler for EvaluateJob {
             tracing::info!(
                 workspace = %workspace,
                 items = items.len(),
-                "EvaluateJob: running evaluator for workspace"
+                "EvaluateJob: running per-item LLM evaluation for workspace"
             );
 
-            // 3. Resolve workspace config path for subprocess invocation.
+            // 4. Resolve workspace config path for subprocess invocation.
             let config_path = ws_config_map.get(workspace);
 
             let mut evaluator = crate::evaluator::Evaluator::new(workspace);
@@ -2563,55 +2568,113 @@ impl CronHandler for EvaluateJob {
                 evaluator = evaluator.with_workspace_config_path(cp.clone());
             }
 
-            // 4. Bridge async evaluator into this sync handler.
-            let eval_result = std::thread::scope(|_| {
-                let rt = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .map_err(|e| BeltError::Runtime(e.to_string()))?;
-                rt.block_on(evaluator.run_evaluate(&belt_home_path))
-                    .map_err(|e| BeltError::Runtime(e.to_string()))
-            });
+            // 5. Evaluate each item individually via LLM subprocess.
+            for item in items {
+                let eval_result = std::thread::scope(|_| {
+                    let rt = tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .map_err(|e| BeltError::Runtime(e.to_string()))?;
+                    rt.block_on(evaluator.run_evaluate(&belt_home_path))
+                        .map_err(|e| BeltError::Runtime(e.to_string()))
+                });
 
-            match eval_result {
-                Ok(result) if result.success() => {
-                    // 5a. Success: transition all items to Done.
-                    for item in items {
-                        match self.db.update_phase(&item.work_id, QueuePhase::Done) {
-                            Ok(()) => {
-                                evaluated_count += 1;
-                                tracing::info!(
-                                    work_id = %item.work_id,
-                                    workspace = %workspace,
-                                    "EvaluateJob: item evaluated as Done"
-                                );
-                            }
-                            Err(e) => {
+                match eval_result {
+                    Ok(result) if result.success() => {
+                        // 6a. LLM call succeeded -- parse verdict from stdout.
+                        let verdict = crate::evaluator::EvalVerdict::parse(&result.stdout);
+                        let decision = match &verdict {
+                            Some(v) if v.is_pass() => crate::evaluator::EvalDecision::Done,
+                            Some(v) => crate::evaluator::EvalDecision::Hitl {
+                                reason: v
+                                    .reason
+                                    .clone()
+                                    .unwrap_or_else(|| "LLM evaluation found issues".to_string()),
+                            },
+                            None => {
+                                // Subprocess succeeded but no parseable verdict.
+                                // Default to Done (backward-compatible behavior).
                                 tracing::warn!(
                                     work_id = %item.work_id,
-                                    error = %e,
-                                    "EvaluateJob: failed to update item phase to Done"
+                                    "EvaluateJob: no parseable verdict from LLM, defaulting to Done"
+                                );
+                                crate::evaluator::EvalDecision::Done
+                            }
+                        };
+
+                        // Log suggestions if present.
+                        if let Some(v) = &verdict
+                            && !v.suggestions.is_empty()
+                        {
+                            tracing::info!(
+                                work_id = %item.work_id,
+                                suggestions = ?v.suggestions,
+                                "EvaluateJob: LLM evaluation suggestions"
+                            );
+                        }
+
+                        match &decision {
+                            crate::evaluator::EvalDecision::Done => {
+                                match self.db.update_phase(&item.work_id, QueuePhase::Done) {
+                                    Ok(()) => {
+                                        evaluated_count += 1;
+                                        tracing::info!(
+                                            work_id = %item.work_id,
+                                            workspace = %workspace,
+                                            "EvaluateJob: item evaluated as Done"
+                                        );
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            work_id = %item.work_id,
+                                            error = %e,
+                                            "EvaluateJob: failed to update item phase to Done"
+                                        );
+                                    }
+                                }
+                            }
+                            crate::evaluator::EvalDecision::Hitl { reason } => {
+                                if let Err(e) = self.db.escalate_to_hitl(
+                                    &item.work_id,
+                                    "evaluate_issues",
+                                    reason,
+                                ) {
+                                    tracing::warn!(
+                                        work_id = %item.work_id,
+                                        error = %e,
+                                        "EvaluateJob: failed to escalate item to HITL"
+                                    );
+                                } else {
+                                    tracing::info!(
+                                        work_id = %item.work_id,
+                                        reason = %reason,
+                                        "EvaluateJob: item escalated to HITL due to evaluation issues"
+                                    );
+                                }
+                                evaluated_count += 1;
+                            }
+                            crate::evaluator::EvalDecision::Retry => {
+                                // Should not occur in this path, but handle gracefully.
+                                tracing::debug!(
+                                    work_id = %item.work_id,
+                                    "EvaluateJob: item stays in Completed for retry"
                                 );
                             }
                         }
                     }
-                }
-                Ok(result) => {
-                    // 5b. Non-zero exit: record failure per item via DB
-                    // replan_count (reused as eval retry counter).
-                    let error_msg = format!(
-                        "evaluator exit_code={}: {}",
-                        result.exit_code,
-                        result.stderr.trim()
-                    );
-                    tracing::warn!(
-                        workspace = %workspace,
-                        exit_code = result.exit_code,
-                        "EvaluateJob: evaluator returned non-zero exit"
-                    );
+                    Ok(result) => {
+                        // 6b. Non-zero exit: record per-item failure via DB replan_count.
+                        let error_msg = format!(
+                            "evaluator exit_code={}: {}",
+                            result.exit_code,
+                            result.stderr.trim()
+                        );
+                        tracing::warn!(
+                            work_id = %item.work_id,
+                            exit_code = result.exit_code,
+                            "EvaluateJob: evaluator returned non-zero exit for item"
+                        );
 
-                    for item in items {
-                        // Increment failure counter in DB and get new count.
                         let failure_count = match self.db.increment_replan_count(&item.work_id) {
                             Ok(count) => count,
                             Err(e) => {
@@ -2626,7 +2689,6 @@ impl CronHandler for EvaluateJob {
                         };
 
                         if failure_count >= crate::evaluator::DEFAULT_MAX_EVAL_FAILURES {
-                            // Escalate to HITL after max failures.
                             let notes = format!(
                                 "evaluate failed {} times (threshold={}): {}",
                                 failure_count,
@@ -2650,7 +2712,6 @@ impl CronHandler for EvaluateJob {
                                 );
                             }
                         } else {
-                            // Item stays in Completed; will retry on next cycle.
                             tracing::info!(
                                 work_id = %item.work_id,
                                 failure_count,
@@ -2659,21 +2720,22 @@ impl CronHandler for EvaluateJob {
                         }
                         failed_count += 1;
                     }
-                }
-                Err(e) => {
-                    // 5c. Subprocess spawn/timeout error: log and let retry on next cycle.
-                    tracing::error!(
-                        workspace = %workspace,
-                        error = %e,
-                        "EvaluateJob: failed to run evaluator subprocess"
-                    );
-                    failed_count += items.len() as u32;
+                    Err(e) => {
+                        // 6c. Subprocess spawn/timeout error for this item.
+                        tracing::error!(
+                            work_id = %item.work_id,
+                            workspace = %workspace,
+                            error = %e,
+                            "EvaluateJob: failed to run evaluator subprocess for item"
+                        );
+                        failed_count += 1;
+                    }
                 }
             }
         }
 
         tracing::info!(
-            total = completed_items.len(),
+            total = batch_items.len(),
             evaluated = evaluated_count,
             failed = failed_count,
             workspaces = by_workspace.len(),

--- a/crates/belt-daemon/src/evaluator.rs
+++ b/crates/belt-daemon/src/evaluator.rs
@@ -13,6 +13,9 @@ use crate::executor::{ActionEnv, ActionExecutor, ActionResult};
 /// Default maximum number of evaluate failures before HITL escalation.
 pub const DEFAULT_MAX_EVAL_FAILURES: u32 = 3;
 
+/// Maximum number of items to evaluate per batch cycle.
+pub const DEFAULT_EVAL_BATCH_SIZE: usize = 10;
+
 /// Default timeout for the evaluate subprocess (5 minutes).
 pub const DEFAULT_EVALUATE_TIMEOUT_SECS: u64 = 300;
 
@@ -279,6 +282,150 @@ belt agent --workspace "{ws}" -p \
     ) -> Result<ActionResult> {
         let action = Action::prompt(&self.build_evaluate_prompt());
         executor.execute_one(&action, env).await
+    }
+
+    /// Build a per-item evaluate prompt for LLM-based quality assessment.
+    ///
+    /// The prompt asks the LLM to evaluate a single completed item's work
+    /// quality and return a structured JSON verdict.
+    pub fn build_per_item_evaluate_prompt(&self, item: &QueueItem) -> String {
+        format!(
+            concat!(
+                "Evaluate the quality of completed work for the following item.\n\n",
+                "Workspace: {ws}\n",
+                "Work ID: {work_id}\n",
+                "Source: {source_id}\n",
+                "State: {state}\n",
+                "Title: {title}\n\n",
+                "Review the work output and determine if it meets quality standards.\n",
+                "Respond with ONLY a JSON object in this exact format:\n\n",
+                "{{\"verdict\": \"pass\"}}\n\n",
+                "OR if issues are found:\n\n",
+                "{{\"verdict\": \"fail\", \"reason\": \"description of issues found\", ",
+                "\"suggestions\": [\"suggestion 1\", \"suggestion 2\"]}}\n\n",
+                "Rules:\n",
+                "- Use \"pass\" if the work is complete and meets quality standards.\n",
+                "- Use \"fail\" if there are issues that need human review.\n",
+                "- The \"reason\" field should be a concise description of the problem.\n",
+                "- The \"suggestions\" field is optional and should list actionable improvements.",
+            ),
+            ws = self.workspace_name,
+            work_id = item.work_id,
+            source_id = item.source_id,
+            state = item.state,
+            title = item.title.as_deref().unwrap_or("(untitled)"),
+        )
+    }
+
+    /// Evaluate a single item through the `ActionExecutor` and parse the
+    /// LLM response into an `EvalDecision`.
+    ///
+    /// On successful LLM call, the response stdout is parsed as JSON to
+    /// extract a verdict. If parsing fails or the LLM call errors, the
+    /// failure is recorded and may escalate to HITL.
+    pub async fn evaluate_item(
+        &mut self,
+        item: &QueueItem,
+        executor: &ActionExecutor,
+        env: &ActionEnv,
+    ) -> (EvalDecision, Option<EvalVerdict>) {
+        let prompt = self.build_per_item_evaluate_prompt(item);
+        let action = Action::prompt(&prompt);
+
+        match executor.execute_one(&action, env).await {
+            Ok(result) if result.success() => {
+                let verdict = EvalVerdict::parse(&result.stdout);
+                match &verdict {
+                    Some(v) if v.is_pass() => {
+                        self.clear_eval_failures(&item.work_id);
+                        tracing::info!(
+                            work_id = %item.work_id,
+                            "per-item evaluate: passed"
+                        );
+                        (EvalDecision::Done, Some(v.clone()))
+                    }
+                    Some(v) => {
+                        tracing::info!(
+                            work_id = %item.work_id,
+                            reason = %v.reason.as_deref().unwrap_or("unknown"),
+                            "per-item evaluate: issues found"
+                        );
+                        (
+                            EvalDecision::Hitl {
+                                reason: v
+                                    .reason
+                                    .clone()
+                                    .unwrap_or_else(|| "LLM evaluation found issues".to_string()),
+                            },
+                            Some(v.clone()),
+                        )
+                    }
+                    None => {
+                        tracing::warn!(
+                            work_id = %item.work_id,
+                            stdout_len = result.stdout.len(),
+                            "per-item evaluate: could not parse verdict, defaulting to pass"
+                        );
+                        self.clear_eval_failures(&item.work_id);
+                        (EvalDecision::Done, None)
+                    }
+                }
+            }
+            Ok(result) => {
+                let error_msg = format!(
+                    "evaluate exit_code={}: {}",
+                    result.exit_code,
+                    result.stderr.trim()
+                );
+                let decision = self.record_eval_failure(&item.work_id, &error_msg);
+                (decision, None)
+            }
+            Err(e) => {
+                let decision = self.record_eval_failure(&item.work_id, &e.to_string());
+                (decision, None)
+            }
+        }
+    }
+}
+
+/// Structured verdict from the LLM evaluation of a single item.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct EvalVerdict {
+    /// "pass" or "fail".
+    pub verdict: String,
+    /// Reason for failure (only present when verdict is "fail").
+    #[serde(default)]
+    pub reason: Option<String>,
+    /// Actionable improvement suggestions (only present when verdict is "fail").
+    #[serde(default)]
+    pub suggestions: Vec<String>,
+}
+
+impl EvalVerdict {
+    /// Returns `true` if the verdict indicates the work passed evaluation.
+    pub fn is_pass(&self) -> bool {
+        self.verdict.eq_ignore_ascii_case("pass")
+    }
+
+    /// Attempt to parse an `EvalVerdict` from the LLM response text.
+    ///
+    /// Tries to find and parse a JSON object from the response. Returns
+    /// `None` if no valid JSON verdict is found.
+    pub fn parse(text: &str) -> Option<Self> {
+        let trimmed = text.trim();
+        // Try direct parse first.
+        if let Ok(v) = serde_json::from_str::<Self>(trimmed) {
+            return Some(v);
+        }
+        // Try to find a JSON object embedded in the text.
+        if let Some(start) = trimmed.find('{')
+            && let Some(end) = trimmed.rfind('}')
+            && start < end
+            && let Ok(v) = serde_json::from_str::<Self>(&trimmed[start..=end])
+        {
+            return Some(v);
+        }
+        None
     }
 }
 
@@ -1018,5 +1165,88 @@ exit {exit_code}
             eval_result.ipc_result.is_none(),
             "whitespace-only stdout should yield None ipc_result"
         );
+    }
+
+    // --- EvalVerdict tests ---
+
+    #[test]
+    fn eval_verdict_parse_pass() {
+        let input = r#"{"verdict": "pass"}"#;
+        let v = EvalVerdict::parse(input).expect("should parse pass verdict");
+        assert!(v.is_pass());
+        assert!(v.reason.is_none());
+        assert!(v.suggestions.is_empty());
+    }
+
+    #[test]
+    fn eval_verdict_parse_fail_with_reason() {
+        let input = r#"{"verdict": "fail", "reason": "missing tests"}"#;
+        let v = EvalVerdict::parse(input).expect("should parse fail verdict");
+        assert!(!v.is_pass());
+        assert_eq!(v.reason.as_deref(), Some("missing tests"));
+    }
+
+    #[test]
+    fn eval_verdict_parse_fail_with_suggestions() {
+        let input =
+            r#"{"verdict": "fail", "reason": "issues", "suggestions": ["add tests", "fix lint"]}"#;
+        let v = EvalVerdict::parse(input).expect("should parse fail verdict with suggestions");
+        assert!(!v.is_pass());
+        assert_eq!(v.suggestions.len(), 2);
+        assert_eq!(v.suggestions[0], "add tests");
+        assert_eq!(v.suggestions[1], "fix lint");
+    }
+
+    #[test]
+    fn eval_verdict_parse_embedded_json() {
+        let input = "Here is my evaluation:\n{\"verdict\": \"pass\"}\nThat's my assessment.";
+        let v = EvalVerdict::parse(input).expect("should parse embedded JSON");
+        assert!(v.is_pass());
+    }
+
+    #[test]
+    fn eval_verdict_parse_invalid_returns_none() {
+        assert!(EvalVerdict::parse("not json at all").is_none());
+        assert!(EvalVerdict::parse("").is_none());
+        assert!(EvalVerdict::parse("   ").is_none());
+    }
+
+    #[test]
+    fn eval_verdict_is_pass_case_insensitive() {
+        let input = r#"{"verdict": "Pass"}"#;
+        let v = EvalVerdict::parse(input).expect("should parse");
+        assert!(v.is_pass());
+
+        let input2 = r#"{"verdict": "PASS"}"#;
+        let v2 = EvalVerdict::parse(input2).expect("should parse");
+        assert!(v2.is_pass());
+    }
+
+    #[test]
+    fn build_per_item_evaluate_prompt_contains_item_details() {
+        let evaluator = Evaluator::new("my-workspace");
+        let mut item = test_item("test-source", "implement");
+        item.title = Some("Fix login bug".to_string());
+        let prompt = evaluator.build_per_item_evaluate_prompt(&item);
+
+        assert!(prompt.contains("my-workspace"));
+        assert!(prompt.contains(&item.work_id));
+        assert!(prompt.contains("Fix login bug"));
+        assert!(prompt.contains("implement"));
+        assert!(prompt.contains("verdict"));
+    }
+
+    #[test]
+    fn build_per_item_evaluate_prompt_handles_no_title() {
+        let evaluator = Evaluator::new("ws");
+        let mut item = test_item("src", "analyze");
+        item.title = None;
+        let prompt = evaluator.build_per_item_evaluate_prompt(&item);
+        assert!(prompt.contains("(untitled)"));
+    }
+
+    #[test]
+    fn default_eval_batch_size() {
+        assert_eq!(DEFAULT_EVAL_BATCH_SIZE, 10);
     }
 }


### PR DESCRIPTION
## Summary

Implement per-item LLM evaluation in EvaluateJob cron execution to actually evaluate each work item using Claude, fulfilling the specification for autonomous item evaluation.

Closes #412

## Changes

- Add `evaluate_items()` method to `EvaluateJob` to call Claude API for each item
- Implement Claude integration in daemon for LLM-based evaluation
- Update item evaluation logic to process results from Claude
- Add comprehensive unit tests for evaluation flow