### PR TITLE
fix(cli): add missing Ok(()) in Windows terminate_pid block

### DIFF
--- a/crates/belt-cli/src/main.rs
+++ b/crates/belt-cli/src/main.rs
@@ -756,6 +756,7 @@ fn terminate_pid(pid: u32) -> anyhow::Result<()> {
             let stderr = String::from_utf8_lossy(&output.stderr);
             anyhow::bail!("taskkill failed for PID {pid}: {stderr}");
         }
+        Ok(())
     }
 
     #[cfg(not(any(unix, windows)))]


### PR DESCRIPTION
## Summary
- Windows `#[cfg(windows)]` 블록에 `Ok(())` 반환 누락으로 v0.1.0 release 빌드 실패
- `terminate_pid()` 함수의 Windows 분기에서 `if` 문 뒤 `Ok(())` 추가

## Test plan
- [x] `cargo check --package belt-cli` 통과
- [ ] CI 통과 확인
- [ ] 머지 후 v0.1.1 태그로 release 재시도

🤖 Generated with [Claude Code](https://claude.com/claude-code)