### PR TITLE
fix(ci): use simple release type for workspace compatibility

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,12 +1,19 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "rust",
+  "release-type": "simple",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": false,
   "packages": {
     ".": {
-      "component": "belt"
+      "component": "belt",
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.package.version"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- `release-type: rust` → `release-type: simple` 변경
- Rust workspace의 `version.workspace = true` 패턴과 호환되지 않아 Release Please 실패
- root `Cargo.toml`의 `$.workspace.package.version`을 TOML extra-file로 직접 타겟팅

## Test plan
- [ ] 머지 후 Release Please 워크플로우 성공 확인
- [ ] Release PR 자동 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)