### PR TITLE
fix(ci): add release event trigger for Release Please compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*"
+  release:
+    types: [published]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Release Please가 GitHub API로 태그/릴리즈를 생성하면 `push:tags` 이벤트가 발생하지 않음
- `release:published` 트리거 추가로 Release Please 릴리즈 시 빌드 워크플로우 자동 실행

## Test plan
- [ ] 머지 후 v0.1.2 릴리즈에 수동으로 바이너리 빌드 트리거하여 확인
- [ ] 다음 릴리즈(v0.1.3+)에서 자동 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)