### PR TITLE
fix(ci): add push trigger with paths filter for release tag creation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,14 @@
 name: Release Please
 
 on:
+  # Manual: creates/updates Release PR
   workflow_dispatch:
+  # Auto: detects merged Release PR and creates tag + release
+  push:
+    branches:
+      - main
+    paths:
+      - '.release-please-manifest.json'
 
 permissions:
   contents: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,10 +60,11 @@ cargo run -- start --config workspace.yaml --tick 30   # 데몬 시작
 
 ## Release
 
-Release Please가 conventional commits를 분석하여 Release PR을 생성한다. **수동 트리거** 방식.
+Release Please가 conventional commits를 분석하여 Release PR을 생성한다.
 
 ```bash
-gh workflow run release-please.yml   # Release PR 생성/업데이트
+gh workflow run release-please.yml   # Release PR 생성/업데이트 (수동)
+# Release PR 머지 시 자동으로 태그 + GitHub Release 생성
 ```
 
 - `feat:` → minor bump, `fix:`/`docs:`/`refactor:` → patch bump


### PR DESCRIPTION
## Summary
- `workflow_dispatch`만으로는 Release PR 머지 후 태그 생성 불가
- `push: main` + `paths: ['.release-please-manifest.json']` 추가
- manifest 파일은 Release PR 머지 시에만 변경되므로 일반 커밋에서는 트리거 안 됨

## 동작
- **수동**: `gh workflow run release-please.yml` → Release PR 생성
- **자동**: Release PR 머지 → manifest 변경 감지 → 태그 + Release 생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)