### PR TITLE
fix(ci): chain release build from release-please via workflow_call

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,8 +17,19 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.rp.outputs.release_created }}
+      tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - id: rp
+        uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  build-and-upload:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/release.yml
+    permissions:
+      contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
-  release:
-    types: [published]
+  workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -96,4 +93,5 @@ jobs:
       - name: Upload assets to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: v${{ github.event.inputs.version || '' }}
           files: artifacts/*


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN`으로 생성된 이벤트(태그/릴리즈)는 다른 워크플로우를 트리거하지 않음 (GitHub 정책)
- `release.yml`을 reusable workflow(`workflow_call`)로 변경
- `release-please.yml`에서 태그 생성 후 `build-and-upload` job으로 직접 호출

## 흐름
```
수동 트리거 → Release PR 생성
Release PR 머지 → manifest 변경 감지 → Release Please 실행
  → release_created=true → build-and-upload 호출
  → 5개 플랫폼 바이너리 빌드 + Release에 첨부
```

## Test plan
- [ ] 머지 후 Release Please 수동 트리거 → Release PR 생성
- [ ] Release PR 머지 → 바이너리 빌드 + 첨부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)