### PR TITLE
fix(ci): pass tag_name from release-please to release build workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,5 +31,7 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     uses: ./.github/workflows/release.yml
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,16 @@ name: Release
 
 on:
   workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
   workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name (e.g. v0.1.5)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -34,6 +43,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -93,5 +104,5 @@ jobs:
       - name: Upload assets to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ github.event.inputs.version || '' }}
+          tag_name: ${{ inputs.tag_name }}
           files: artifacts/*


### PR DESCRIPTION
## Summary
- v0.1.5 릴리즈에서 `tag_name: v` (빈 값)으로 upload되어 바이너리가 잘못된 릴리즈에 첨부됨
- `release-please.yml` → `release.yml`로 `tag_name` input 전달
- `release.yml`에 `workflow_call.inputs.tag_name` + `workflow_dispatch.inputs.tag_name` 정의
- checkout도 `ref: ${{ inputs.tag_name }}`으로 올바른 태그 체크아웃

🤖 Generated with [Claude Code](https://claude.com/claude-code)