### PR TITLE
fix(dist): redirect installer say() output to stderr

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ _tmpdir=""
 # --- Helpers ---
 
 say() {
-    printf 'belt-installer: %s\n' "$*"
+    printf 'belt-installer: %s\n' "$*" >&2
 }
 
 err() {


### PR DESCRIPTION
## Summary
- `say()`가 stdout으로 출력되어 `resolve_version()` 반환값에 로그 메시지가 섞임
- 다운로드 URL이 `https://.../vbelt-installer: fetching...` 형태로 깨짐
- `say()` 출력을 stderr로 리다이렉트하여 수정

## Test plan
- [x] `bash install.sh` — v0.1.6 정상 설치 확인
- [x] `belt --version` — `belt 0.1.6` 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)