### PR TITLE
fix(daemon): replan max exceeded should transition to Skipped, not Failed

### DIFF
--- a/crates/belt-daemon/src/cron.rs
+++ b/crates/belt-daemon/src/cron.rs
@@ -615,7 +615,7 @@ impl CronHandler for HitlTimeoutJob {
             // and finally default to Failed (safe default).
             let target_phase = match item.hitl_terminal_action.as_deref() {
                 Some("skip") => QueuePhase::Skipped,
-                Some("replan") => QueuePhase::Failed,
+                Some("replan") => QueuePhase::Skipped,
                 Some("failed") => QueuePhase::Failed,
                 _ => resolve_workspace_terminal_phase(
                     &self.db,
@@ -4487,9 +4487,9 @@ fn middleware(request: Request, secret: &[u8], rules: &[ValidationRule]) -> Resp
         let ctx = CronContext { now: Utc::now() };
         job.execute(&ctx).unwrap();
 
-        // "replan" maps to Failed (item goes back to queue for re-processing).
+        // "replan" maps to Skipped (replan max exceeded should not use Failed).
         let updated = db.get_item("w-replan").unwrap();
-        assert_eq!(updated.phase, QueuePhase::Failed);
+        assert_eq!(updated.phase, QueuePhase::Skipped);
     }
 
     #[test]

--- a/crates/belt-daemon/src/daemon.rs
+++ b/crates/belt-daemon/src/daemon.rs
@@ -972,7 +972,7 @@ impl Daemon {
     /// For `Replan`, the item is rolled back to Pending with an incremented
     /// `replan_count`, and a new HITL item is created to delegate spec
     /// modification to the Claw agent. If `replan_count` exceeds
-    /// [`Self::MAX_REPLAN_COUNT`], the item transitions to Failed instead.
+    /// [`Self::MAX_REPLAN_COUNT`], the item transitions to Skipped instead.
     pub fn respond_hitl(
         &mut self,
         work_id: &str,
@@ -1067,16 +1067,16 @@ impl Daemon {
                         work_id,
                         replan_count = new_replan_count,
                         max = Self::MAX_REPLAN_COUNT,
-                        "replan limit exceeded, transitioning to Failed"
+                        "replan limit exceeded, transitioning to Skipped"
                     );
                     item.replan_count = new_replan_count;
-                    let from = transit(item, QueuePhase::Failed)?;
+                    let from = transit(item, QueuePhase::Skipped)?;
                     Self::record_transition(
                         &self.db,
                         work_id,
                         &source_id_clone,
                         from,
-                        QueuePhase::Failed,
+                        QueuePhase::Skipped,
                         "handler",
                         Some("replan limit exceeded".to_string()),
                     );
@@ -3492,7 +3492,7 @@ sources:
     }
 
     #[test]
-    fn respond_hitl_replan_exceeds_limit_transitions_to_failed() {
+    fn respond_hitl_replan_exceeds_limit_transitions_to_skipped() {
         let tmp = TempDir::new().unwrap();
         let source = MockDataSource::new("github");
         let mut daemon = setup_daemon(&tmp, source, vec![]);
@@ -3505,9 +3505,9 @@ sources:
         let result = daemon.respond_hitl("s1:analyze", HitlRespondAction::Replan, None, None);
         assert!(result.is_ok());
 
-        // Should transition to Failed, not Pending.
+        // Should transition to Skipped, not Pending.
         let original = daemon.get_item("s1:analyze").unwrap();
-        assert_eq!(original.phase, QueuePhase::Failed);
+        assert_eq!(original.phase, QueuePhase::Skipped);
         assert_eq!(original.replan_count, 4);
 
         // No replan HITL item should be created.


### PR DESCRIPTION
## Summary

Autopilot 자동 구현

Closes #487

## Changes

- Fix daemon replan max exceeded logic to transition to Skipped state instead of Failed state
- Ensures proper state transition for items that exceed maximum replan attempts