### PR TITLE
fix(core): IssueContext missing state field in belt context output

### DIFF
--- a/crates/belt-core/src/context.rs
+++ b/crates/belt-core/src/context.rs
@@ -102,6 +102,7 @@ pub struct IssueContext {
     pub body: Option<String>,
     pub labels: Vec<String>,
     pub author: String,
+    pub state: String,
 }
 
 /// PR context including review information, branch details, and labels.
@@ -290,6 +291,7 @@ mod tests {
                 body: Some("Implement JWT".to_string()),
                 labels: vec!["autodev:implement".to_string()],
                 author: "irene".to_string(),
+                state: "open".to_string(),
             }),
             pr: None,
             history,

--- a/crates/belt-infra/src/sources/github.rs
+++ b/crates/belt-infra/src/sources/github.rs
@@ -43,7 +43,7 @@ impl GitHubDataSource {
     async fn fetch_issue(
         repo: &str,
         number: i64,
-    ) -> Option<(String, Option<String>, Vec<String>, String)> {
+    ) -> Option<(String, Option<String>, Vec<String>, String, String)> {
         let output = tokio::process::Command::new("gh")
             .args([
                 "issue",
@@ -72,8 +72,9 @@ impl GitHubDataSource {
             })
             .unwrap_or_default();
         let author = val["author"]["login"].as_str().unwrap_or("").to_string();
+        let state = val["state"].as_str().unwrap_or("open").to_string();
 
-        Some((title, body, labels, author))
+        Some((title, body, labels, author, state))
     }
 
     /// `gh` CLI로 해당 이슈에 연결된 PR을 조회한다.
@@ -457,12 +458,13 @@ impl DataSource for GitHubDataSource {
             Self::fetch_default_branch(&repo_name),
         );
 
-        let (title, body, labels, author) = issue_data.unwrap_or_else(|| {
+        let (title, body, labels, author, issue_state) = issue_data.unwrap_or_else(|| {
             (
                 item.title.clone().unwrap_or_default(),
                 None,
                 vec![],
                 String::new(),
+                "open".to_string(),
             )
         });
 
@@ -485,6 +487,7 @@ impl DataSource for GitHubDataSource {
                 body,
                 labels,
                 author,
+                state: issue_state,
             }),
             pr: pr_data,
             history: vec![],


### PR DESCRIPTION
## Summary

Autopilot 자동 구현으로 IssueContext의 belt context output에서 누락된 state 필드를 추가합니다.

Closes #497

## Changes

- Added missing state field to IssueContext in belt context output
- Ensures all required context fields are properly exported