### PR TITLE
fix(ci): Release Please fails with stale PR node ID on label assignment

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
       - id: rp
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@8bb7a2ed0f90c9802c83129a9488d235a1f31a7c # v4 + release-please 17.3.0
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Closes #585

## Summary
- Pin release-please-action to commit with release-please 17.3.0 (fixes stale node ID bug)
- Retain skip-labeling: true as defense in depth