### PR TITLE
fix(core): convert ShellExecutor to async trait (#614)

### DIFF
--- a/crates/belt-core/src/platform.rs
+++ b/crates/belt-core/src/platform.rs
@@ -7,6 +7,8 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use async_trait::async_trait;
+
 use crate::error::BeltError;
 
 /// Result of executing a shell command.
@@ -32,10 +34,11 @@ impl ShellOutput {
 /// Implementations translate a command string into the appropriate shell
 /// invocation for the target platform (e.g. `bash -c` on Unix,
 /// `cmd.exe /C` on Windows).
+#[async_trait]
 pub trait ShellExecutor: Send + Sync {
-    /// Execute `command` synchronously in `working_dir` with optional
+    /// Execute `command` asynchronously in `working_dir` with optional
     /// environment variables.
-    fn execute(
+    async fn execute(
         &self,
         command: &str,
         working_dir: &Path,

--- a/crates/belt-core/src/test_runner.rs
+++ b/crates/belt-core/src/test_runner.rs
@@ -5,6 +5,8 @@
 
 use std::path::Path;
 
+use async_trait::async_trait;
+
 use crate::error::BeltError;
 
 /// Result of executing a single test command.
@@ -32,6 +34,7 @@ pub struct TestRunResult {
 /// Implementations receive a list of shell commands and a working directory,
 /// then execute them sequentially and report results. The `fail_fast` flag
 /// controls whether execution stops at the first failure.
+#[async_trait]
 pub trait TestRunner: Send + Sync {
     /// Run the given test commands in `working_dir`.
     ///
@@ -39,7 +42,7 @@ pub trait TestRunner: Send + Sync {
     /// Individual command failures are captured in [`TestRunResult`] rather than
     /// returned as errors. Errors are reserved for cases where a command cannot
     /// be spawned at all.
-    fn run(
+    async fn run(
         &self,
         commands: &[&str],
         working_dir: &Path,

--- a/crates/belt-daemon/src/cron.rs
+++ b/crates/belt-daemon/src/cron.rs
@@ -1912,11 +1912,14 @@ impl CronHandler for GapDetectionJob {
                     "GapDetectionJob: running test commands for spec"
                 );
 
-                match belt_infra::test_runner::run_test_commands(
-                    &test_cmds,
-                    &self.workspace_root,
-                    true, // fail-fast
-                ) {
+                let handle = tokio::runtime::Handle::current();
+                match tokio::task::block_in_place(|| {
+                    handle.block_on(belt_infra::test_runner::run_test_commands(
+                        &test_cmds,
+                        &self.workspace_root,
+                        true, // fail-fast
+                    ))
+                }) {
                     Ok(result) if result.all_passed => {
                         tracing::info!(
                             spec_id = %spec_id,
@@ -3066,7 +3069,10 @@ impl CronHandler for CustomScriptJob {
 
         let working_dir = std::path::PathBuf::from(&belt_home);
 
-        let output = self.shell.execute(&self.script, &working_dir, &env_vars)?;
+        let handle = tokio::runtime::Handle::current();
+        let output = tokio::task::block_in_place(|| {
+            handle.block_on(self.shell.execute(&self.script, &working_dir, &env_vars))
+        })?;
 
         if !output.success() {
             tracing::error!(

--- a/crates/belt-daemon/src/executor.rs
+++ b/crates/belt-daemon/src/executor.rs
@@ -169,14 +169,7 @@ impl ActionExecutor {
             env_vars.insert(k.clone(), v.clone());
         }
 
-        let shell = Arc::clone(&self.shell);
-        let command = command.to_string();
-        let working_dir = env.worktree.clone();
-
-        let output =
-            tokio::task::spawn_blocking(move || shell.execute(&command, &working_dir, &env_vars))
-                .await
-                .map_err(|e| anyhow::anyhow!("shell task join error: {e}"))?;
+        let output = self.shell.execute(command, &env.worktree, &env_vars).await;
 
         let duration = start.elapsed();
 

--- a/crates/belt-infra/src/platform/mod.rs
+++ b/crates/belt-infra/src/platform/mod.rs
@@ -60,14 +60,15 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[test]
-    fn default_shell_executor_can_run_command() {
+    #[tokio::test]
+    async fn default_shell_executor_can_run_command() {
         let executor = default_shell_executor();
         let tmp = tempfile::tempdir().unwrap();
         let env = std::collections::HashMap::new();
 
         let output = executor
             .execute("echo factory_test", tmp.path(), &env)
+            .await
             .unwrap();
         assert!(output.success());
         assert!(output.stdout.contains("factory_test"));

--- a/crates/belt-infra/src/platform/unix.rs
+++ b/crates/belt-infra/src/platform/unix.rs
@@ -5,7 +5,9 @@
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::process::Command;
+
+use async_trait::async_trait;
+use tokio::process::Command;
 
 use belt_core::error::BeltError;
 use belt_core::platform::{DaemonNotifier, ShellExecutor, ShellOutput};
@@ -14,8 +16,9 @@ use belt_core::platform::{DaemonNotifier, ShellExecutor, ShellOutput};
 #[derive(Debug, Default, Clone)]
 pub struct UnixShellExecutor;
 
+#[async_trait]
 impl ShellExecutor for UnixShellExecutor {
-    fn execute(
+    async fn execute(
         &self,
         command: &str,
         working_dir: &Path,
@@ -27,6 +30,7 @@ impl ShellExecutor for UnixShellExecutor {
             .current_dir(working_dir)
             .envs(env_vars)
             .output()
+            .await
             .map_err(|e| {
                 BeltError::Runtime(format!("failed to spawn shell command '{command}': {e}"))
             })?;
@@ -63,54 +67,59 @@ impl DaemonNotifier for UnixDaemonNotifier {
 mod tests {
     use super::*;
 
-    #[test]
-    fn execute_echo() {
+    #[tokio::test]
+    async fn execute_echo() {
         let executor = UnixShellExecutor;
         let result = executor
             .execute("echo hello", Path::new("/tmp"), &HashMap::new())
+            .await
             .unwrap();
         assert!(result.success());
         assert!(result.stdout.contains("hello"));
     }
 
-    #[test]
-    fn execute_with_env_vars() {
+    #[tokio::test]
+    async fn execute_with_env_vars() {
         let executor = UnixShellExecutor;
         let mut env = HashMap::new();
         env.insert("MY_TEST_VAR".to_string(), "test_value".to_string());
         let result = executor
             .execute("echo $MY_TEST_VAR", Path::new("/tmp"), &env)
+            .await
             .unwrap();
         assert!(result.success());
         assert!(result.stdout.contains("test_value"));
     }
 
-    #[test]
-    fn execute_failing_command() {
+    #[tokio::test]
+    async fn execute_failing_command() {
         let executor = UnixShellExecutor;
         let result = executor
             .execute("exit 42", Path::new("/tmp"), &HashMap::new())
+            .await
             .unwrap();
         assert!(!result.success());
         assert_eq!(result.exit_code, Some(42));
     }
 
-    #[test]
-    fn execute_captures_stderr() {
+    #[tokio::test]
+    async fn execute_captures_stderr() {
         let executor = UnixShellExecutor;
         let result = executor
             .execute("echo err_msg >&2", Path::new("/tmp"), &HashMap::new())
+            .await
             .unwrap();
         assert!(result.success());
         assert!(result.stderr.contains("err_msg"));
     }
 
-    #[test]
-    fn execute_respects_working_dir() {
+    #[tokio::test]
+    async fn execute_respects_working_dir() {
         let executor = UnixShellExecutor;
         let tmp = tempfile::tempdir().unwrap();
         let result = executor
             .execute("pwd", tmp.path(), &HashMap::new())
+            .await
             .unwrap();
         assert!(result.success());
         // Resolve symlinks for macOS /tmp -> /private/tmp

--- a/crates/belt-infra/src/platform/windows.rs
+++ b/crates/belt-infra/src/platform/windows.rs
@@ -5,7 +5,9 @@
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::process::Command;
+
+use async_trait::async_trait;
+use tokio::process::Command;
 
 use belt_core::error::BeltError;
 use belt_core::platform::{DaemonNotifier, ShellExecutor, ShellOutput};
@@ -14,8 +16,9 @@ use belt_core::platform::{DaemonNotifier, ShellExecutor, ShellOutput};
 #[derive(Debug, Default, Clone)]
 pub struct WindowsShellExecutor;
 
+#[async_trait]
 impl ShellExecutor for WindowsShellExecutor {
-    fn execute(
+    async fn execute(
         &self,
         command: &str,
         working_dir: &Path,
@@ -27,6 +30,7 @@ impl ShellExecutor for WindowsShellExecutor {
             .current_dir(working_dir)
             .envs(env_vars)
             .output()
+            .await
             .map_err(|e| {
                 BeltError::Runtime(format!("failed to spawn shell command '{command}': {e}"))
             })?;
@@ -76,20 +80,23 @@ mod tests {
     // These tests execute cmd.exe and only run on Windows.
 
     #[cfg(target_os = "windows")]
-    #[test]
-    fn execute_echo_command() {
+    #[tokio::test]
+    async fn execute_echo_command() {
         let executor = WindowsShellExecutor;
         let tmp = tempfile::tempdir().unwrap();
         let env = HashMap::new();
 
-        let output = executor.execute("echo hello", tmp.path(), &env).unwrap();
+        let output = executor
+            .execute("echo hello", tmp.path(), &env)
+            .await
+            .unwrap();
         assert!(output.success());
         assert!(output.stdout.contains("hello"));
     }
 
     #[cfg(target_os = "windows")]
-    #[test]
-    fn execute_with_env_vars() {
+    #[tokio::test]
+    async fn execute_with_env_vars() {
         let executor = WindowsShellExecutor;
         let tmp = tempfile::tempdir().unwrap();
         let mut env = HashMap::new();
@@ -97,32 +104,37 @@ mod tests {
 
         let output = executor
             .execute("echo %BELT_TEST_VAR%", tmp.path(), &env)
+            .await
             .unwrap();
         assert!(output.success());
         assert!(output.stdout.contains("test_value"));
     }
 
     #[cfg(target_os = "windows")]
-    #[test]
-    fn execute_failing_command() {
+    #[tokio::test]
+    async fn execute_failing_command() {
         let executor = WindowsShellExecutor;
         let tmp = tempfile::tempdir().unwrap();
         let env = HashMap::new();
 
-        let output = executor.execute("exit /b 42", tmp.path(), &env).unwrap();
+        let output = executor
+            .execute("exit /b 42", tmp.path(), &env)
+            .await
+            .unwrap();
         assert!(!output.success());
         assert_eq!(output.exit_code, Some(42));
     }
 
     #[cfg(target_os = "windows")]
-    #[test]
-    fn execute_captures_stderr() {
+    #[tokio::test]
+    async fn execute_captures_stderr() {
         let executor = WindowsShellExecutor;
         let tmp = tempfile::tempdir().unwrap();
         let env = HashMap::new();
 
         let output = executor
             .execute("echo error_msg >&2", tmp.path(), &env)
+            .await
             .unwrap();
         assert!(output.stderr.contains("error_msg"));
     }
@@ -131,13 +143,13 @@ mod tests {
     // On non-Windows, cmd.exe is unavailable so we verify that execute returns an error.
 
     #[cfg(not(target_os = "windows"))]
-    #[test]
-    fn execute_fails_on_non_windows() {
+    #[tokio::test]
+    async fn execute_fails_on_non_windows() {
         let executor = WindowsShellExecutor;
         let tmp = tempfile::tempdir().unwrap();
         let env = HashMap::new();
 
-        let result = executor.execute("echo hello", tmp.path(), &env);
+        let result = executor.execute("echo hello", tmp.path(), &env).await;
         assert!(
             result.is_err(),
             "cmd.exe should not be available on non-Windows"

--- a/crates/belt-infra/src/test_runner.rs
+++ b/crates/belt-infra/src/test_runner.rs
@@ -11,6 +11,8 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
+use async_trait::async_trait;
+
 use belt_core::error::BeltError;
 use belt_core::platform::ShellExecutor;
 use belt_core::test_runner::{TestCommandResult, TestRunResult, TestRunner};
@@ -50,14 +52,15 @@ impl ShellTestRunner {
     }
 }
 
+#[async_trait]
 impl TestRunner for ShellTestRunner {
-    fn run(
+    async fn run(
         &self,
         commands: &[&str],
         working_dir: &Path,
         fail_fast: bool,
     ) -> Result<TestRunResult, BeltError> {
-        run_test_commands_with_shell(&*self.shell, commands, working_dir, fail_fast)
+        run_test_commands_with_shell(&*self.shell, commands, working_dir, fail_fast).await
     }
 }
 
@@ -73,8 +76,8 @@ impl TestRunner for ShellTestRunner {
 /// Returns `BeltError::Runtime` if a command cannot be spawned at all.
 /// Individual command failures are captured in the returned `TestRunResult`
 /// rather than as errors.
-pub fn run_test_commands_with_shell(
-    shell: &dyn ShellExecutor,
+pub async fn run_test_commands_with_shell(
+    shell: &(dyn ShellExecutor + '_),
     commands: &[&str],
     working_dir: &Path,
     fail_fast: bool,
@@ -84,7 +87,7 @@ pub fn run_test_commands_with_shell(
     let empty_env = HashMap::new();
 
     for cmd in commands {
-        let output = shell.execute(cmd, working_dir, &empty_env)?;
+        let output = shell.execute(cmd, working_dir, &empty_env).await?;
 
         let success = output.success();
         let combined = format!("{}{}", output.stdout, output.stderr);
@@ -121,93 +124,111 @@ pub fn run_test_commands_with_shell(
 ///
 /// This preserves backward compatibility with existing callers that do not
 /// need to inject a custom [`ShellExecutor`].
-pub fn run_test_commands(
+pub async fn run_test_commands(
     commands: &[&str],
     working_dir: &Path,
     fail_fast: bool,
 ) -> Result<TestRunResult, BeltError> {
     let shell = crate::platform::default_shell_executor();
-    run_test_commands_with_shell(&*shell, commands, working_dir, fail_fast)
+    run_test_commands_with_shell(&*shell, commands, working_dir, fail_fast).await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn run_passing_command() {
+    #[tokio::test]
+    async fn run_passing_command() {
         let tmp = tempfile::tempdir().unwrap();
-        let result = run_test_commands(&["true"], tmp.path(), false).unwrap();
+        let result = run_test_commands(&["true"], tmp.path(), false)
+            .await
+            .unwrap();
         assert!(result.all_passed);
         assert_eq!(result.results.len(), 1);
         assert!(result.results[0].success);
     }
 
-    #[test]
-    fn run_failing_command() {
+    #[tokio::test]
+    async fn run_failing_command() {
         let tmp = tempfile::tempdir().unwrap();
-        let result = run_test_commands(&["false"], tmp.path(), false).unwrap();
+        let result = run_test_commands(&["false"], tmp.path(), false)
+            .await
+            .unwrap();
         assert!(!result.all_passed);
         assert_eq!(result.results.len(), 1);
         assert!(!result.results[0].success);
     }
 
-    #[test]
-    fn fail_fast_stops_at_first_failure() {
+    #[tokio::test]
+    async fn fail_fast_stops_at_first_failure() {
         let tmp = tempfile::tempdir().unwrap();
-        let result = run_test_commands(&["false", "true"], tmp.path(), true).unwrap();
+        let result = run_test_commands(&["false", "true"], tmp.path(), true)
+            .await
+            .unwrap();
         assert!(!result.all_passed);
         assert_eq!(result.results.len(), 1);
     }
 
-    #[test]
-    fn no_fail_fast_runs_all_commands() {
+    #[tokio::test]
+    async fn no_fail_fast_runs_all_commands() {
         let tmp = tempfile::tempdir().unwrap();
-        let result = run_test_commands(&["false", "true"], tmp.path(), false).unwrap();
+        let result = run_test_commands(&["false", "true"], tmp.path(), false)
+            .await
+            .unwrap();
         assert!(!result.all_passed);
         assert_eq!(result.results.len(), 2);
         assert!(!result.results[0].success);
         assert!(result.results[1].success);
     }
 
-    #[test]
-    fn empty_commands_all_pass() {
+    #[tokio::test]
+    async fn empty_commands_all_pass() {
         let tmp = tempfile::tempdir().unwrap();
-        let result = run_test_commands(&[], tmp.path(), false).unwrap();
+        let result = run_test_commands(&[], tmp.path(), false).await.unwrap();
         assert!(result.all_passed);
         assert!(result.results.is_empty());
     }
 
-    #[test]
-    fn captures_output() {
+    #[tokio::test]
+    async fn captures_output() {
         let tmp = tempfile::tempdir().unwrap();
-        let result = run_test_commands(&["echo hello_test"], tmp.path(), false).unwrap();
+        let result = run_test_commands(&["echo hello_test"], tmp.path(), false)
+            .await
+            .unwrap();
         assert!(result.all_passed);
         assert!(result.results[0].output.contains("hello_test"));
     }
 
-    #[test]
-    fn multiple_passing_commands() {
+    #[tokio::test]
+    async fn multiple_passing_commands() {
         let tmp = tempfile::tempdir().unwrap();
-        let result = run_test_commands(&["true", "true", "true"], tmp.path(), false).unwrap();
+        let result = run_test_commands(&["true", "true", "true"], tmp.path(), false)
+            .await
+            .unwrap();
         assert!(result.all_passed);
         assert_eq!(result.results.len(), 3);
     }
 
-    #[test]
-    fn shell_test_runner_trait_impl() {
+    #[tokio::test]
+    async fn shell_test_runner_trait_impl() {
         let runner = ShellTestRunner::new();
         let tmp = tempfile::tempdir().unwrap();
-        let result = runner.run(&["true", "echo ok"], tmp.path(), false).unwrap();
+        let result = runner
+            .run(&["true", "echo ok"], tmp.path(), false)
+            .await
+            .unwrap();
         assert!(result.all_passed);
         assert_eq!(result.results.len(), 2);
     }
 
-    #[test]
-    fn shell_test_runner_fail_fast() {
+    #[tokio::test]
+    async fn shell_test_runner_fail_fast() {
         let runner = ShellTestRunner::new();
         let tmp = tempfile::tempdir().unwrap();
-        let result = runner.run(&["false", "true"], tmp.path(), true).unwrap();
+        let result = runner
+            .run(&["false", "true"], tmp.path(), true)
+            .await
+            .unwrap();
         assert!(!result.all_passed);
         assert_eq!(result.results.len(), 1);
     }


### PR DESCRIPTION
## Summary

Autopilot 자동 구현

Closes #614

## Changes

Converted ShellExecutor and TestRunner to async traits for better async/await support in the Belt runtime.