### PR TITLE
feat(daemon): implement Progressive Evaluation Pipeline (MechanicalStage + SemanticStage)

### DIFF
--- a/crates/belt-cli/src/agent.rs
+++ b/crates/belt-cli/src/agent.rs
@@ -368,6 +368,7 @@ fn default_agent_config() -> WorkspaceConfig {
         concurrency: 1,
         sources: HashMap::new(),
         runtime: RuntimeConfig::default(),
+        evaluate: None,
         claw_config: None,
     }
 }
@@ -640,6 +641,7 @@ mod tests {
             concurrency: 1,
             sources: HashMap::new(),
             runtime: RuntimeConfig::default(),
+            evaluate: None,
             claw_config: None,
         }
     }
@@ -698,6 +700,7 @@ mod tests {
             concurrency: 2,
             sources,
             runtime: RuntimeConfig::default(),
+            evaluate: None,
             claw_config: None,
         }
     }

--- a/crates/belt-core/Cargo.toml
+++ b/crates/belt-core/Cargo.toml
@@ -12,6 +12,7 @@ thiserror = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 anyhow = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 serde_yaml = { workspace = true }

--- a/crates/belt-core/src/evaluation.rs
+++ b/crates/belt-core/src/evaluation.rs
@@ -1,0 +1,258 @@
+//! Progressive Evaluation Pipeline — trait definitions and pipeline composition.
+//!
+//! Evaluation proceeds through stages ordered by cost (cheapest first).
+//! Each stage can return a definitive decision or `Inconclusive` to delegate
+//! to the next stage. If all stages are inconclusive, the pipeline escalates
+//! to HITL.
+//!
+//! ## Stages (v6)
+//!
+//! 1. **MechanicalStage** — deterministic checks (cargo test, clippy, etc.) in worktree. Cost $0.
+//! 2. **SemanticStage** — single LLM call to judge whether the work is sufficient.
+//!
+//! Adding a new stage (e.g. `ConsensusStage` in v7) requires zero core changes (OCP).
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+
+/// Evaluation context passed to each stage.
+///
+/// Contains the information a stage needs to perform its judgment.
+#[derive(Debug, Clone)]
+pub struct EvalContext {
+    /// The work_id of the queue item being evaluated.
+    pub work_id: String,
+    /// The source_id of the queue item.
+    pub source_id: String,
+    /// The workspace name.
+    pub workspace_name: String,
+    /// Path to the worktree directory for this item.
+    pub worktree_path: Option<PathBuf>,
+}
+
+/// Decision produced by an evaluation stage.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EvalDecision {
+    /// Work is sufficient — trigger on_done hook and transit to Done.
+    Done,
+    /// Human review needed — create HITL event.
+    Hitl { reason: String },
+    /// Mechanical check failed — handler should re-execute (no LLM cost).
+    Retry,
+    /// This stage cannot make a definitive judgment — pass to the next stage.
+    Inconclusive,
+}
+
+/// A single evaluation stage in the progressive pipeline.
+///
+/// Implementors perform one kind of judgment (mechanical, semantic, consensus, etc.)
+/// and return an [`EvalDecision`]. Returning `Inconclusive` delegates to the next stage.
+#[async_trait]
+pub trait EvaluationStage: Send + Sync {
+    /// Human-readable name for logging and diagnostics.
+    fn name(&self) -> &str;
+
+    /// Perform evaluation and return a decision.
+    ///
+    /// - `Done` / `Hitl` / `Retry` are definitive — the pipeline stops.
+    /// - `Inconclusive` means this stage cannot judge — the next stage runs.
+    async fn evaluate(&self, ctx: &EvalContext) -> anyhow::Result<EvalDecision>;
+}
+
+/// Composite pipeline that runs stages in order (cheapest first).
+///
+/// When a stage returns a definitive decision, the pipeline short-circuits.
+/// If all stages return `Inconclusive`, the pipeline escalates to HITL.
+pub struct EvaluationPipeline {
+    stages: Vec<Box<dyn EvaluationStage>>,
+}
+
+impl EvaluationPipeline {
+    /// Create a new pipeline with the given stages (ordered cheapest-first).
+    pub fn new(stages: Vec<Box<dyn EvaluationStage>>) -> Self {
+        Self { stages }
+    }
+
+    /// Create an empty pipeline (all items will escalate to HITL).
+    pub fn empty() -> Self {
+        Self { stages: vec![] }
+    }
+
+    /// Return the number of registered stages.
+    pub fn stage_count(&self) -> usize {
+        self.stages.len()
+    }
+
+    /// Return the names of registered stages in order.
+    pub fn stage_names(&self) -> Vec<&str> {
+        self.stages.iter().map(|s| s.name()).collect()
+    }
+
+    /// Run stages sequentially. Stop on the first definitive decision.
+    ///
+    /// If all stages return `Inconclusive`, escalates to HITL as a safe default.
+    pub async fn evaluate(&self, ctx: &EvalContext) -> anyhow::Result<EvalDecision> {
+        for stage in &self.stages {
+            let decision = stage.evaluate(ctx).await?;
+            match decision {
+                EvalDecision::Inconclusive => {
+                    tracing::debug!(
+                        stage = stage.name(),
+                        work_id = %ctx.work_id,
+                        "stage returned Inconclusive, proceeding to next"
+                    );
+                    continue;
+                }
+                definitive => {
+                    tracing::info!(
+                        stage = stage.name(),
+                        work_id = %ctx.work_id,
+                        decision = ?definitive,
+                        "stage returned definitive decision"
+                    );
+                    return Ok(definitive);
+                }
+            }
+        }
+
+        // All stages inconclusive — safe default is HITL.
+        tracing::warn!(
+            work_id = %ctx.work_id,
+            "all {} stages returned Inconclusive, escalating to HITL",
+            self.stages.len()
+        );
+        Ok(EvalDecision::Hitl {
+            reason: "all stages inconclusive".into(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A test stage that always returns a fixed decision.
+    struct FixedStage {
+        stage_name: &'static str,
+        decision: EvalDecision,
+    }
+
+    #[async_trait]
+    impl EvaluationStage for FixedStage {
+        fn name(&self) -> &str {
+            self.stage_name
+        }
+        async fn evaluate(&self, _ctx: &EvalContext) -> anyhow::Result<EvalDecision> {
+            Ok(self.decision.clone())
+        }
+    }
+
+    fn test_ctx() -> EvalContext {
+        EvalContext {
+            work_id: "test:implement".into(),
+            source_id: "test".into(),
+            workspace_name: "test-ws".into(),
+            worktree_path: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn pipeline_short_circuits_on_done() {
+        let pipeline = EvaluationPipeline::new(vec![
+            Box::new(FixedStage {
+                stage_name: "mechanical",
+                decision: EvalDecision::Inconclusive,
+            }),
+            Box::new(FixedStage {
+                stage_name: "semantic",
+                decision: EvalDecision::Done,
+            }),
+        ]);
+
+        let decision = pipeline.evaluate(&test_ctx()).await.unwrap();
+        assert_eq!(decision, EvalDecision::Done);
+    }
+
+    #[tokio::test]
+    async fn pipeline_short_circuits_on_retry() {
+        let pipeline = EvaluationPipeline::new(vec![
+            Box::new(FixedStage {
+                stage_name: "mechanical",
+                decision: EvalDecision::Retry,
+            }),
+            Box::new(FixedStage {
+                stage_name: "semantic",
+                decision: EvalDecision::Done,
+            }),
+        ]);
+
+        let decision = pipeline.evaluate(&test_ctx()).await.unwrap();
+        assert_eq!(decision, EvalDecision::Retry);
+    }
+
+    #[tokio::test]
+    async fn pipeline_escalates_hitl_when_all_inconclusive() {
+        let pipeline = EvaluationPipeline::new(vec![
+            Box::new(FixedStage {
+                stage_name: "mechanical",
+                decision: EvalDecision::Inconclusive,
+            }),
+            Box::new(FixedStage {
+                stage_name: "semantic",
+                decision: EvalDecision::Inconclusive,
+            }),
+        ]);
+
+        let decision = pipeline.evaluate(&test_ctx()).await.unwrap();
+        assert!(matches!(decision, EvalDecision::Hitl { .. }));
+    }
+
+    #[tokio::test]
+    async fn empty_pipeline_escalates_to_hitl() {
+        let pipeline = EvaluationPipeline::empty();
+        let decision = pipeline.evaluate(&test_ctx()).await.unwrap();
+        assert!(matches!(decision, EvalDecision::Hitl { .. }));
+    }
+
+    #[test]
+    fn stage_names_returns_ordered_names() {
+        let pipeline = EvaluationPipeline::new(vec![
+            Box::new(FixedStage {
+                stage_name: "mechanical",
+                decision: EvalDecision::Inconclusive,
+            }),
+            Box::new(FixedStage {
+                stage_name: "semantic",
+                decision: EvalDecision::Done,
+            }),
+        ]);
+
+        assert_eq!(pipeline.stage_names(), vec!["mechanical", "semantic"]);
+        assert_eq!(pipeline.stage_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn pipeline_hitl_decision_stops_pipeline() {
+        let pipeline = EvaluationPipeline::new(vec![
+            Box::new(FixedStage {
+                stage_name: "mechanical",
+                decision: EvalDecision::Hitl {
+                    reason: "test failure".into(),
+                },
+            }),
+            Box::new(FixedStage {
+                stage_name: "semantic",
+                decision: EvalDecision::Done,
+            }),
+        ]);
+
+        let decision = pipeline.evaluate(&test_ctx()).await.unwrap();
+        assert_eq!(
+            decision,
+            EvalDecision::Hitl {
+                reason: "test failure".into()
+            }
+        );
+    }
+}

--- a/crates/belt-core/src/lib.rs
+++ b/crates/belt-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod context;
 pub mod dependency;
 pub mod error;
 pub mod escalation;
+pub mod evaluation;
 pub mod lifecycle;
 pub mod phase;
 pub mod platform;

--- a/crates/belt-core/src/workspace.rs
+++ b/crates/belt-core/src/workspace.rs
@@ -14,9 +14,34 @@ pub struct WorkspaceConfig {
     pub sources: HashMap<String, SourceConfig>,
     #[serde(default)]
     pub runtime: RuntimeConfig,
+    /// Progressive evaluation pipeline configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evaluate: Option<EvaluateConfig>,
     /// Per-workspace Claw configuration overrides.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub claw_config: Option<ClawConfig>,
+}
+
+/// Evaluation pipeline configuration.
+///
+/// Defines the mechanical (deterministic) checks that run before the
+/// semantic (LLM) evaluation stage. If `mechanical` is empty or absent,
+/// the pipeline skips directly to semantic evaluation.
+///
+/// ```yaml
+/// evaluate:
+///   mechanical:
+///     - "cargo test"
+///     - "cargo clippy -- -D warnings"
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct EvaluateConfig {
+    /// Shell commands to run in the worktree for deterministic verification.
+    ///
+    /// Each command is executed sequentially. If any command fails (non-zero
+    /// exit code), the item is marked for retry without invoking the LLM.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mechanical: Vec<String>,
 }
 
 /// Per-workspace Claw configuration.
@@ -384,5 +409,45 @@ claw_config:
         let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
         let claw = config.claw_config.unwrap();
         assert!(claw.max_conversation_turns.is_none());
+    }
+
+    #[test]
+    fn evaluate_defaults_to_none() {
+        let yaml = "name: minimal\nsources:\n  github:\n    url: https://github.com/org/repo\n";
+        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.evaluate.is_none());
+    }
+
+    #[test]
+    fn evaluate_parses_mechanical_commands() {
+        let yaml = r#"
+name: with-eval
+sources:
+  github:
+    url: https://github.com/org/repo
+evaluate:
+  mechanical:
+    - "cargo test"
+    - "cargo clippy -- -D warnings"
+"#;
+        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        let eval = config.evaluate.unwrap();
+        assert_eq!(eval.mechanical.len(), 2);
+        assert_eq!(eval.mechanical[0], "cargo test");
+        assert_eq!(eval.mechanical[1], "cargo clippy -- -D warnings");
+    }
+
+    #[test]
+    fn evaluate_empty_mechanical_defaults_to_empty_vec() {
+        let yaml = r#"
+name: empty-eval
+sources:
+  github:
+    url: https://github.com/org/repo
+evaluate: {}
+"#;
+        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        let eval = config.evaluate.unwrap();
+        assert!(eval.mechanical.is_empty());
     }
 }

--- a/crates/belt-daemon/src/evaluation_stages.rs
+++ b/crates/belt-daemon/src/evaluation_stages.rs
@@ -1,0 +1,377 @@
+//! Concrete evaluation stage implementations for the progressive pipeline.
+//!
+//! - [`MechanicalStage`] — runs deterministic shell commands in the worktree (cost $0).
+//! - [`SemanticStage`] — delegates to an LLM via `belt agent -p` subprocess (cost: 1 LLM call).
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use belt_core::evaluation::{EvalContext, EvalDecision, EvaluationStage};
+use belt_core::platform::ShellExecutor;
+
+use crate::executor::{ActionEnv, ActionExecutor};
+
+// ---------------------------------------------------------------------------
+// MechanicalStage
+// ---------------------------------------------------------------------------
+
+/// Stage 1: deterministic verification in the worktree.
+///
+/// Runs each configured shell command sequentially. If any command fails
+/// (non-zero exit code), returns `Retry` so the handler re-executes without
+/// incurring LLM cost. If all commands pass (or no commands are configured),
+/// returns `Inconclusive` to delegate to the next stage.
+pub struct MechanicalStage {
+    /// Shell commands to execute (from workspace yaml `evaluate.mechanical`).
+    commands: Vec<String>,
+    /// Platform shell executor for running commands.
+    shell: Arc<dyn ShellExecutor>,
+}
+
+impl MechanicalStage {
+    /// Create a new mechanical stage with the given commands and shell executor.
+    pub fn new(commands: Vec<String>, shell: Arc<dyn ShellExecutor>) -> Self {
+        Self { commands, shell }
+    }
+}
+
+#[async_trait]
+impl EvaluationStage for MechanicalStage {
+    fn name(&self) -> &str {
+        "mechanical"
+    }
+
+    async fn evaluate(&self, ctx: &EvalContext) -> Result<EvalDecision> {
+        // No commands configured — pass through to next stage.
+        if self.commands.is_empty() {
+            tracing::debug!(
+                work_id = %ctx.work_id,
+                "mechanical stage: no commands configured, passing through"
+            );
+            return Ok(EvalDecision::Inconclusive);
+        }
+
+        let worktree_path = match &ctx.worktree_path {
+            Some(path) => path.clone(),
+            None => {
+                tracing::warn!(
+                    work_id = %ctx.work_id,
+                    "mechanical stage: no worktree path, skipping"
+                );
+                return Ok(EvalDecision::Inconclusive);
+            }
+        };
+
+        let env_vars = HashMap::new();
+
+        for cmd in &self.commands {
+            tracing::info!(
+                work_id = %ctx.work_id,
+                command = %cmd,
+                worktree = %worktree_path.display(),
+                "mechanical stage: running command"
+            );
+
+            let output = self.shell.execute(cmd, &worktree_path, &env_vars).await;
+
+            match output {
+                Ok(result) if result.success() => {
+                    tracing::debug!(
+                        work_id = %ctx.work_id,
+                        command = %cmd,
+                        "mechanical stage: command passed"
+                    );
+                }
+                Ok(result) => {
+                    tracing::info!(
+                        work_id = %ctx.work_id,
+                        command = %cmd,
+                        exit_code = ?result.exit_code,
+                        stderr = %result.stderr.chars().take(500).collect::<String>(),
+                        "mechanical stage: command failed, returning Retry"
+                    );
+                    return Ok(EvalDecision::Retry);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        work_id = %ctx.work_id,
+                        command = %cmd,
+                        error = %e,
+                        "mechanical stage: command execution error, returning Retry"
+                    );
+                    return Ok(EvalDecision::Retry);
+                }
+            }
+        }
+
+        tracing::info!(
+            work_id = %ctx.work_id,
+            commands_passed = self.commands.len(),
+            "mechanical stage: all commands passed, proceeding to next stage"
+        );
+        Ok(EvalDecision::Inconclusive)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SemanticStage
+// ---------------------------------------------------------------------------
+
+/// Stage 2: LLM-based semantic judgment.
+///
+/// Wraps the existing `belt agent -p` subprocess invocation. The LLM
+/// evaluates whether the completed work is sufficient based on the issue
+/// context, handler output, and history.
+///
+/// This stage always returns a definitive decision (Done or Hitl) — it
+/// never returns `Inconclusive` since it is the final stage in v6.
+pub struct SemanticStage {
+    /// The workspace name for prompt construction.
+    workspace_name: String,
+    /// The action executor for running the LLM prompt.
+    executor: Arc<ActionExecutor>,
+}
+
+impl SemanticStage {
+    /// Create a new semantic stage.
+    pub fn new(workspace_name: String, executor: Arc<ActionExecutor>) -> Self {
+        Self {
+            workspace_name,
+            executor,
+        }
+    }
+
+    /// Build the evaluate prompt for the LLM.
+    fn build_prompt(&self) -> String {
+        format!(
+            "Completed 아이템의 완료 여부를 판단하고, belt queue done 또는 belt queue hitl 을 실행해줘 (workspace: {ws})",
+            ws = self.workspace_name
+        )
+    }
+}
+
+#[async_trait]
+impl EvaluationStage for SemanticStage {
+    fn name(&self) -> &str {
+        "semantic"
+    }
+
+    async fn evaluate(&self, ctx: &EvalContext) -> Result<EvalDecision> {
+        let action = belt_core::action::Action::prompt(&self.build_prompt());
+        let working_dir = ctx.worktree_path.as_deref().unwrap_or(Path::new("/tmp"));
+        let env = ActionEnv::new(&ctx.work_id, working_dir);
+
+        tracing::info!(
+            work_id = %ctx.work_id,
+            workspace = %self.workspace_name,
+            "semantic stage: invoking LLM evaluation"
+        );
+
+        match self.executor.execute_one(&action, &env).await {
+            Ok(result) if result.success() => {
+                tracing::info!(
+                    work_id = %ctx.work_id,
+                    "semantic stage: LLM evaluation succeeded, returning Done"
+                );
+                Ok(EvalDecision::Done)
+            }
+            Ok(result) => {
+                tracing::warn!(
+                    work_id = %ctx.work_id,
+                    exit_code = result.exit_code,
+                    stderr = %result.stderr.chars().take(500).collect::<String>(),
+                    "semantic stage: LLM evaluation failed, returning Hitl"
+                );
+                Ok(EvalDecision::Hitl {
+                    reason: format!(
+                        "semantic evaluation failed (exit_code={}): {}",
+                        result.exit_code,
+                        result.stderr.chars().take(200).collect::<String>()
+                    ),
+                })
+            }
+            Err(e) => {
+                tracing::error!(
+                    work_id = %ctx.work_id,
+                    error = %e,
+                    "semantic stage: LLM invocation error"
+                );
+                Err(e)
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline builder
+// ---------------------------------------------------------------------------
+
+/// Build an [`EvaluationPipeline`] from workspace configuration.
+///
+/// If `mechanical_commands` is empty, only the semantic stage is registered.
+/// This preserves backward compatibility — behavior is identical to the
+/// previous single-batch LLM call when no mechanical config exists.
+pub fn build_pipeline(
+    workspace_name: &str,
+    mechanical_commands: Vec<String>,
+    executor: Arc<ActionExecutor>,
+    shell: Arc<dyn ShellExecutor>,
+) -> belt_core::evaluation::EvaluationPipeline {
+    let mut stages: Vec<Box<dyn EvaluationStage>> = Vec::new();
+
+    // Stage 1: Mechanical (only if commands are configured).
+    if !mechanical_commands.is_empty() {
+        stages.push(Box::new(MechanicalStage::new(mechanical_commands, shell)));
+    }
+
+    // Stage 2: Semantic (always present).
+    stages.push(Box::new(SemanticStage::new(
+        workspace_name.to_string(),
+        executor,
+    )));
+
+    belt_core::evaluation::EvaluationPipeline::new(stages)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use belt_core::error::BeltError;
+    use belt_core::evaluation::EvalContext;
+    use belt_core::platform::ShellOutput;
+
+    /// A mock shell executor for testing.
+    struct MockShell {
+        /// Exit codes to return for each successive call.
+        exit_codes: std::sync::Mutex<Vec<i32>>,
+    }
+
+    impl MockShell {
+        fn new(exit_codes: Vec<i32>) -> Self {
+            Self {
+                exit_codes: std::sync::Mutex::new(exit_codes),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ShellExecutor for MockShell {
+        async fn execute(
+            &self,
+            _command: &str,
+            _working_dir: &Path,
+            _env_vars: &HashMap<String, String>,
+        ) -> Result<ShellOutput, BeltError> {
+            let code = {
+                let mut codes = self.exit_codes.lock().unwrap();
+                if codes.is_empty() { 0 } else { codes.remove(0) }
+            };
+            Ok(ShellOutput {
+                exit_code: Some(code),
+                stdout: String::new(),
+                stderr: if code != 0 {
+                    "command failed".into()
+                } else {
+                    String::new()
+                },
+            })
+        }
+    }
+
+    fn test_ctx_with_worktree() -> EvalContext {
+        EvalContext {
+            work_id: "test:implement".into(),
+            source_id: "test".into(),
+            workspace_name: "test-ws".into(),
+            worktree_path: Some(std::path::PathBuf::from("/tmp/worktree")),
+        }
+    }
+
+    fn test_ctx_no_worktree() -> EvalContext {
+        EvalContext {
+            work_id: "test:implement".into(),
+            source_id: "test".into(),
+            workspace_name: "test-ws".into(),
+            worktree_path: None,
+        }
+    }
+
+    // --- MechanicalStage tests ---
+
+    #[tokio::test]
+    async fn mechanical_no_commands_returns_inconclusive() {
+        let shell = Arc::new(MockShell::new(vec![]));
+        let stage = MechanicalStage::new(vec![], shell);
+
+        let decision = stage.evaluate(&test_ctx_with_worktree()).await.unwrap();
+        assert_eq!(decision, EvalDecision::Inconclusive);
+    }
+
+    #[tokio::test]
+    async fn mechanical_all_pass_returns_inconclusive() {
+        let shell = Arc::new(MockShell::new(vec![0, 0]));
+        let stage = MechanicalStage::new(vec!["cargo test".into(), "cargo clippy".into()], shell);
+
+        let decision = stage.evaluate(&test_ctx_with_worktree()).await.unwrap();
+        assert_eq!(decision, EvalDecision::Inconclusive);
+    }
+
+    #[tokio::test]
+    async fn mechanical_first_fails_returns_retry() {
+        let shell = Arc::new(MockShell::new(vec![1]));
+        let stage = MechanicalStage::new(vec!["cargo test".into(), "cargo clippy".into()], shell);
+
+        let decision = stage.evaluate(&test_ctx_with_worktree()).await.unwrap();
+        assert_eq!(decision, EvalDecision::Retry);
+    }
+
+    #[tokio::test]
+    async fn mechanical_second_fails_returns_retry() {
+        let shell = Arc::new(MockShell::new(vec![0, 1]));
+        let stage = MechanicalStage::new(vec!["cargo test".into(), "cargo clippy".into()], shell);
+
+        let decision = stage.evaluate(&test_ctx_with_worktree()).await.unwrap();
+        assert_eq!(decision, EvalDecision::Retry);
+    }
+
+    #[tokio::test]
+    async fn mechanical_no_worktree_returns_inconclusive() {
+        let shell = Arc::new(MockShell::new(vec![0]));
+        let stage = MechanicalStage::new(vec!["cargo test".into()], shell);
+
+        let decision = stage.evaluate(&test_ctx_no_worktree()).await.unwrap();
+        assert_eq!(decision, EvalDecision::Inconclusive);
+    }
+
+    // --- build_pipeline tests ---
+
+    #[test]
+    fn build_pipeline_without_mechanical_has_one_stage() {
+        use belt_core::runtime::RuntimeRegistry;
+
+        let registry = Arc::new(RuntimeRegistry::new("mock".into()));
+        let executor = Arc::new(ActionExecutor::new(registry));
+        let shell = Arc::new(MockShell::new(vec![]));
+
+        let pipeline = build_pipeline("test-ws", vec![], executor, shell);
+        assert_eq!(pipeline.stage_count(), 1);
+        assert_eq!(pipeline.stage_names(), vec!["semantic"]);
+    }
+
+    #[test]
+    fn build_pipeline_with_mechanical_has_two_stages() {
+        use belt_core::runtime::RuntimeRegistry;
+
+        let registry = Arc::new(RuntimeRegistry::new("mock".into()));
+        let executor = Arc::new(ActionExecutor::new(registry));
+        let shell = Arc::new(MockShell::new(vec![]));
+
+        let pipeline = build_pipeline("test-ws", vec!["cargo test".into()], executor, shell);
+        assert_eq!(pipeline.stage_count(), 2);
+        assert_eq!(pipeline.stage_names(), vec!["mechanical", "semantic"]);
+    }
+}

--- a/crates/belt-daemon/src/evaluator.rs
+++ b/crates/belt-daemon/src/evaluator.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use anyhow::Result;
 
 use belt_core::action::Action;
+use belt_core::evaluation::{EvalContext, EvalDecision as PipelineDecision, EvaluationPipeline};
 use belt_core::phase::QueuePhase;
 use belt_core::queue::QueueItem;
 use belt_core::runtime::TokenUsage;
@@ -45,6 +46,11 @@ pub struct Evaluator {
     workspace_config_path: Option<PathBuf>,
     /// Timeout for the evaluate subprocess.
     evaluate_timeout: Duration,
+    /// Progressive evaluation pipeline (MechanicalStage + SemanticStage).
+    ///
+    /// When set, `evaluate_item` uses the pipeline instead of the legacy
+    /// subprocess call. When `None`, falls back to the original behavior.
+    pipeline: Option<EvaluationPipeline>,
 }
 
 impl Evaluator {
@@ -55,6 +61,7 @@ impl Evaluator {
             max_eval_failures: DEFAULT_MAX_EVAL_FAILURES,
             workspace_config_path: None,
             evaluate_timeout: Duration::from_secs(DEFAULT_EVALUATE_TIMEOUT_SECS),
+            pipeline: None,
         }
     }
 
@@ -74,6 +81,73 @@ impl Evaluator {
     pub fn with_evaluate_timeout(mut self, timeout: Duration) -> Self {
         self.evaluate_timeout = timeout;
         self
+    }
+
+    /// Set the progressive evaluation pipeline.
+    ///
+    /// When a pipeline is configured, [`evaluate_item`] runs items through
+    /// the staged pipeline instead of the legacy subprocess call.
+    pub fn with_pipeline(mut self, pipeline: EvaluationPipeline) -> Self {
+        self.pipeline = Some(pipeline);
+        self
+    }
+
+    /// Returns `true` if this evaluator has a pipeline configured.
+    pub fn has_pipeline(&self) -> bool {
+        self.pipeline.is_some()
+    }
+
+    /// Evaluate a single item through the progressive pipeline.
+    ///
+    /// Converts the pipeline's [`PipelineDecision`] into the evaluator's
+    /// [`EvalDecision`], maintaining failure tracking and HITL escalation.
+    ///
+    /// Returns `None` if no pipeline is configured (caller should fall back
+    /// to the legacy subprocess approach).
+    pub async fn evaluate_item(
+        &mut self,
+        item: &QueueItem,
+        worktree_path: Option<PathBuf>,
+    ) -> Option<Result<EvalDecision>> {
+        let pipeline = self.pipeline.as_ref()?;
+
+        let ctx = EvalContext {
+            work_id: item.work_id.clone(),
+            source_id: item.source_id.clone(),
+            workspace_name: self.workspace_name.clone(),
+            worktree_path,
+        };
+
+        let result = pipeline.evaluate(&ctx).await;
+
+        Some(match result {
+            Ok(decision) => {
+                let eval_decision = match decision {
+                    PipelineDecision::Done => {
+                        self.clear_eval_failures(&item.work_id);
+                        EvalDecision::Done
+                    }
+                    PipelineDecision::Hitl { reason } => EvalDecision::Hitl { reason },
+                    PipelineDecision::Retry => {
+                        // Use failure tracking to escalate after repeated retries.
+                        self.record_eval_failure(&item.work_id, "pipeline retry")
+                    }
+                    PipelineDecision::Inconclusive => {
+                        // Should not happen — pipeline escalates to HITL.
+                        // But handle defensively.
+                        EvalDecision::Hitl {
+                            reason: "pipeline returned Inconclusive (unexpected)".into(),
+                        }
+                    }
+                };
+                Ok(eval_decision)
+            }
+            Err(e) => {
+                let decision =
+                    self.record_eval_failure(&item.work_id, &format!("pipeline error: {e}"));
+                Ok(decision)
+            }
+        })
     }
 
     pub fn filter_completed(items: &[QueueItem]) -> Vec<&QueueItem> {

--- a/crates/belt-daemon/src/lib.rs
+++ b/crates/belt-daemon/src/lib.rs
@@ -5,5 +5,6 @@ pub mod advancer;
 pub mod concurrency;
 pub mod cron;
 pub mod daemon;
+pub mod evaluation_stages;
 pub mod evaluator;
 pub mod executor;


### PR DESCRIPTION
## Summary

Autopilot 자동 구현

Closes #759

## Changes

- **belt-core/src/evaluation.rs**: Added EvalContext, EvalDecision, EvaluationStage trait, and EvaluationPipeline with comprehensive testing (6 tests)
- **belt-core/src/workspace.rs**: Added EvaluateConfig with mechanical commands support
- **belt-daemon/src/evaluation_stages.rs**: Implemented MechanicalStage and SemanticStage components with factory function build_pipeline() (7 tests)
- **belt-daemon/src/evaluator.rs**: Integrated pipeline evaluation with evaluate_item() method
- Backward compatible — opt-in via with_pipeline()