### PR TITLE
feat(core): implement Stagnation Detection module (SimilarityJudge, PatternDetector, LateralAnalyzer)

### DIFF
--- a/crates/belt-cli/src/main.rs
+++ b/crates/belt-cli/src/main.rs
@@ -1437,6 +1437,10 @@ fn recommended_action(
             "done",
             "Spec modification proposed; review changes and approve or skip.",
         ),
+        Some(HitlReason::StagnationDetected) => (
+            "replan",
+            "Stagnation detected; replan with a lateral approach to break the loop.",
+        ),
         None => (
             "skip",
             "No HITL reason recorded; review manually and decide.",
@@ -4383,6 +4387,7 @@ sources:
             worktree_preserved: false,
             previous_worktree_path: None,
             replan_count: 0,
+            lateral_plan: None,
         }
     }
 

--- a/crates/belt-core/src/lib.rs
+++ b/crates/belt-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod queue;
 pub mod runtime;
 pub mod source;
 pub mod spec;
+pub mod stagnation;
 pub mod state_machine;
 pub mod test_runner;
 pub mod workspace;

--- a/crates/belt-core/src/queue.rs
+++ b/crates/belt-core/src/queue.rs
@@ -21,6 +21,8 @@ pub enum HitlReason {
     ManualEscalation,
     /// Spec 충돌 감지 — 파일 수준 overlap으로 사람의 판단 필요.
     SpecConflict,
+    /// 정체 감지 — 에이전트가 반복/진동/무진전 등의 stagnation 패턴을 보임.
+    StagnationDetected,
     /// spec Completing 단계 최종 확인 (gap-detection 통과 후 HITL 승인 대기).
     SpecCompletionReview,
     /// Claw 에이전트가 제안한 스펙 수정.
@@ -35,6 +37,7 @@ impl fmt::Display for HitlReason {
             HitlReason::Timeout => f.write_str("timeout"),
             HitlReason::ManualEscalation => f.write_str("manual_escalation"),
             HitlReason::SpecConflict => f.write_str("spec_conflict"),
+            HitlReason::StagnationDetected => f.write_str("stagnation_detected"),
             HitlReason::SpecCompletionReview => f.write_str("spec_completion_review"),
             HitlReason::SpecModificationProposed => f.write_str("spec_modification_proposed"),
         }
@@ -161,6 +164,9 @@ pub struct QueueItem {
     /// Replan 시도 횟수. 무한 루프 방지를 위해 최대 3회로 제한한다.
     #[serde(default, skip_serializing_if = "is_zero")]
     pub replan_count: u32,
+    /// Lateral plan (serialized JSON) — stagnation 감지 시 LateralAnalyzer가 생성한 계획.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lateral_plan: Option<String>,
 }
 
 fn is_zero(v: &u32) -> bool {
@@ -188,6 +194,7 @@ impl QueueItem {
             worktree_preserved: false,
             previous_worktree_path: None,
             replan_count: 0,
+            lateral_plan: None,
         }
     }
 
@@ -237,6 +244,7 @@ pub struct QueueItemRow {
     pub worktree_preserved: bool,
     pub previous_worktree_path: Option<String>,
     pub replan_count: u32,
+    pub lateral_plan: Option<String>,
 }
 
 impl QueueItem {
@@ -259,6 +267,7 @@ impl QueueItem {
             worktree_preserved: self.worktree_preserved,
             previous_worktree_path: self.previous_worktree_path.clone(),
             replan_count: self.replan_count,
+            lateral_plan: self.lateral_plan.clone(),
         }
     }
 
@@ -275,6 +284,7 @@ impl QueueItem {
                 "spec_conflict" => Ok(HitlReason::SpecConflict),
                 "spec_completion_review" => Ok(HitlReason::SpecCompletionReview),
                 "spec_modification_proposed" => Ok(HitlReason::SpecModificationProposed),
+                "stagnation_detected" => Ok(HitlReason::StagnationDetected),
                 other => Err(format!("invalid hitl_reason: {other}")),
             })
             .transpose()?;
@@ -301,6 +311,7 @@ impl QueueItem {
             worktree_preserved: row.worktree_preserved,
             previous_worktree_path: row.previous_worktree_path.clone(),
             replan_count: row.replan_count,
+            lateral_plan: row.lateral_plan.clone(),
         })
     }
 
@@ -337,6 +348,7 @@ pub mod testing {
             worktree_preserved: false,
             previous_worktree_path: None,
             replan_count: 0,
+            lateral_plan: None,
         }
     }
 }

--- a/crates/belt-core/src/stagnation/lateral.rs
+++ b/crates/belt-core/src/stagnation/lateral.rs
@@ -1,0 +1,227 @@
+//! Lateral thinking analysis for breaking out of stagnation.
+//!
+//! When a stagnation pattern is detected, [`LateralAnalyzer`] selects
+//! a [`Persona`] that suggests a fundamentally different approach,
+//! producing a [`LateralPlan`] that can guide the next agent attempt.
+
+use serde::{Deserialize, Serialize};
+
+use super::pattern::{StagnationDetection, StagnationPattern};
+
+/// A lateral-thinking persona that frames the problem from a different angle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Persona {
+    /// "Hack it until it works" — quick, pragmatic, possibly dirty.
+    Hacker,
+    /// Step back and redesign the architecture.
+    Architect,
+    /// Research prior art, docs, and similar solutions.
+    Researcher,
+    /// Radically simplify — remove code, reduce scope.
+    Simplifier,
+    /// Challenge every assumption that led here.
+    Contrarian,
+}
+
+impl Persona {
+    /// All available personas.
+    pub const ALL: [Persona; 5] = [
+        Persona::Hacker,
+        Persona::Architect,
+        Persona::Researcher,
+        Persona::Simplifier,
+        Persona::Contrarian,
+    ];
+
+    /// A short directive that characterizes this persona's approach.
+    pub fn directive(&self) -> &'static str {
+        match self {
+            Persona::Hacker => {
+                "Take the most pragmatic shortcut. Hardcode, monkey-patch, \
+                 or use an escape hatch — make it work first, clean up later."
+            }
+            Persona::Architect => {
+                "Step back and reconsider the design. Look for a structural change \
+                 (new abstraction, different data flow) that avoids the current obstacle."
+            }
+            Persona::Researcher => {
+                "Search documentation, prior issues, and known patterns for this kind of problem. \
+                 Someone has likely solved this before."
+            }
+            Persona::Simplifier => {
+                "Aggressively reduce scope. Remove unnecessary code, simplify the approach, \
+                 and strip the solution to its minimal form."
+            }
+            Persona::Contrarian => {
+                "Challenge the assumptions. What if the requirement is wrong? \
+                 What if the constraint we're working around doesn't actually apply?"
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for Persona {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Persona::Hacker => f.write_str("hacker"),
+            Persona::Architect => f.write_str("architect"),
+            Persona::Researcher => f.write_str("researcher"),
+            Persona::Simplifier => f.write_str("simplifier"),
+            Persona::Contrarian => f.write_str("contrarian"),
+        }
+    }
+}
+
+/// A plan produced by lateral analysis to break out of stagnation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LateralPlan {
+    /// The selected persona.
+    pub persona: Persona,
+    /// The persona's directive text.
+    pub directive: String,
+    /// The stagnation pattern that triggered this plan.
+    pub triggered_by: StagnationPattern,
+    /// Confidence of the original detection.
+    pub detection_confidence: f64,
+}
+
+/// Selects a [`Persona`] based on the detected stagnation pattern.
+///
+/// The mapping is deterministic:
+/// - `Spinning` → `Contrarian` (same output = wrong assumptions)
+/// - `Oscillation` → `Architect` (flip-flopping = structural problem)
+/// - `NoDrift` → `Researcher` (no progress = need external knowledge)
+/// - `DiminishingReturns` → `Simplifier` (incremental gains plateau = over-engineering)
+///
+/// A `Hacker` persona is available as a fallback or can be selected manually.
+#[derive(Debug, Default)]
+pub struct LateralAnalyzer;
+
+impl LateralAnalyzer {
+    /// Create a new analyzer.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Given a stagnation detection, produce a lateral plan.
+    pub fn analyze(&self, detection: &StagnationDetection) -> LateralPlan {
+        let persona = self.select_persona(detection.pattern);
+        LateralPlan {
+            persona,
+            directive: persona.directive().to_string(),
+            triggered_by: detection.pattern,
+            detection_confidence: detection.confidence,
+        }
+    }
+
+    /// Select a persona for the given pattern.
+    pub fn select_persona(&self, pattern: StagnationPattern) -> Persona {
+        match pattern {
+            StagnationPattern::Spinning => Persona::Contrarian,
+            StagnationPattern::Oscillation => Persona::Architect,
+            StagnationPattern::NoDrift => Persona::Researcher,
+            StagnationPattern::DiminishingReturns => Persona::Simplifier,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn persona_display() {
+        assert_eq!(Persona::Hacker.to_string(), "hacker");
+        assert_eq!(Persona::Architect.to_string(), "architect");
+        assert_eq!(Persona::Researcher.to_string(), "researcher");
+        assert_eq!(Persona::Simplifier.to_string(), "simplifier");
+        assert_eq!(Persona::Contrarian.to_string(), "contrarian");
+    }
+
+    #[test]
+    fn persona_all_has_five() {
+        assert_eq!(Persona::ALL.len(), 5);
+    }
+
+    #[test]
+    fn persona_serde_roundtrip() {
+        for persona in Persona::ALL {
+            let json = serde_json::to_string(&persona).unwrap();
+            let parsed: Persona = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, persona);
+        }
+    }
+
+    #[test]
+    fn persona_directive_non_empty() {
+        for persona in Persona::ALL {
+            assert!(!persona.directive().is_empty());
+        }
+    }
+
+    #[test]
+    fn lateral_analyzer_spinning_selects_contrarian() {
+        let analyzer = LateralAnalyzer::new();
+        assert_eq!(
+            analyzer.select_persona(StagnationPattern::Spinning),
+            Persona::Contrarian
+        );
+    }
+
+    #[test]
+    fn lateral_analyzer_oscillation_selects_architect() {
+        let analyzer = LateralAnalyzer::new();
+        assert_eq!(
+            analyzer.select_persona(StagnationPattern::Oscillation),
+            Persona::Architect
+        );
+    }
+
+    #[test]
+    fn lateral_analyzer_no_drift_selects_researcher() {
+        let analyzer = LateralAnalyzer::new();
+        assert_eq!(
+            analyzer.select_persona(StagnationPattern::NoDrift),
+            Persona::Researcher
+        );
+    }
+
+    #[test]
+    fn lateral_analyzer_diminishing_returns_selects_simplifier() {
+        let analyzer = LateralAnalyzer::new();
+        assert_eq!(
+            analyzer.select_persona(StagnationPattern::DiminishingReturns),
+            Persona::Simplifier
+        );
+    }
+
+    #[test]
+    fn lateral_plan_from_detection() {
+        let analyzer = LateralAnalyzer::new();
+        let detection = StagnationDetection {
+            pattern: StagnationPattern::Spinning,
+            confidence: 0.95,
+            reason: "3 consecutive identical outputs".to_string(),
+        };
+        let plan = analyzer.analyze(&detection);
+        assert_eq!(plan.persona, Persona::Contrarian);
+        assert_eq!(plan.triggered_by, StagnationPattern::Spinning);
+        assert!((plan.detection_confidence - 0.95).abs() < f64::EPSILON);
+        assert!(!plan.directive.is_empty());
+    }
+
+    #[test]
+    fn lateral_plan_serde_roundtrip() {
+        let plan = LateralPlan {
+            persona: Persona::Architect,
+            directive: "redesign".to_string(),
+            triggered_by: StagnationPattern::Oscillation,
+            detection_confidence: 0.8,
+        };
+        let json = serde_json::to_string(&plan).unwrap();
+        let parsed: LateralPlan = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.persona, plan.persona);
+        assert_eq!(parsed.triggered_by, plan.triggered_by);
+    }
+}

--- a/crates/belt-core/src/stagnation/mod.rs
+++ b/crates/belt-core/src/stagnation/mod.rs
@@ -1,0 +1,33 @@
+//! Stagnation detection and lateral thinking module.
+//!
+//! Detects when an agent is stuck in a loop (spinning, oscillating, etc.)
+//! and suggests alternative approaches via persona-based lateral analysis.
+//!
+//! # Architecture
+//!
+//! ```text
+//! Agent outputs
+//!   │
+//!   ▼
+//! SimilarityJudge ──► PatternDetector ──► StagnationDetector
+//!                                               │
+//!                                               ▼
+//!                                        LateralAnalyzer ──► LateralPlan
+//! ```
+//!
+//! - [`similarity`]: Judges how similar two outputs are (ExactHash, TokenFingerprint).
+//! - [`pattern`]: Detects stagnation patterns (Spinning, Oscillation, NoDrift, DiminishingReturns).
+//! - [`lateral`]: Selects a persona-based strategy to break out of stagnation.
+
+pub mod lateral;
+pub mod pattern;
+pub mod similarity;
+
+pub use lateral::{LateralAnalyzer, LateralPlan, Persona};
+pub use pattern::{
+    OscillationDetector, PatternDetector, SpinningDetector, StagnationDetection,
+    StagnationDetector, StagnationPattern,
+};
+pub use similarity::{
+    CompositeSimilarity, ExactHash, SimilarityJudge, SimilarityScore, TokenFingerprint,
+};

--- a/crates/belt-core/src/stagnation/pattern.rs
+++ b/crates/belt-core/src/stagnation/pattern.rs
@@ -1,0 +1,330 @@
+//! Stagnation pattern detection.
+//!
+//! Defines [`StagnationPattern`] enum representing detected stagnation types,
+//! [`StagnationDetection`] as the detection result, and [`PatternDetector`] trait
+//! with [`SpinningDetector`] and [`OscillationDetector`] implementations.
+
+use serde::{Deserialize, Serialize};
+
+use super::similarity::{SimilarityJudge, SimilarityScore};
+
+/// A recognized stagnation pattern.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StagnationPattern {
+    /// Agent produces nearly identical outputs across consecutive attempts.
+    Spinning,
+    /// Agent alternates between two (or few) distinct outputs.
+    Oscillation,
+    /// Agent output changes but the evaluation score does not improve.
+    NoDrift,
+    /// Each successive attempt yields smaller improvements, approaching zero.
+    DiminishingReturns,
+}
+
+impl std::fmt::Display for StagnationPattern {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StagnationPattern::Spinning => f.write_str("spinning"),
+            StagnationPattern::Oscillation => f.write_str("oscillation"),
+            StagnationPattern::NoDrift => f.write_str("no_drift"),
+            StagnationPattern::DiminishingReturns => f.write_str("diminishing_returns"),
+        }
+    }
+}
+
+/// Result of a pattern detection pass.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StagnationDetection {
+    /// The detected pattern.
+    pub pattern: StagnationPattern,
+    /// Confidence level in `[0.0, 1.0]`.
+    pub confidence: f64,
+    /// Human-readable explanation of why the pattern was detected.
+    pub reason: String,
+}
+
+/// Detect a specific stagnation pattern from a history of outputs.
+pub trait PatternDetector: Send + Sync {
+    /// Analyze `outputs` (oldest first) and return a detection if the pattern is found.
+    fn detect(&self, outputs: &[&str]) -> Option<StagnationDetection>;
+
+    /// Which pattern this detector targets.
+    fn target_pattern(&self) -> StagnationPattern;
+}
+
+/// Detects [`StagnationPattern::Spinning`] — consecutive near-identical outputs.
+pub struct SpinningDetector {
+    judge: Box<dyn SimilarityJudge>,
+    /// Minimum similarity to consider two outputs as "the same".
+    threshold: SimilarityScore,
+    /// Number of consecutive similar pairs required to declare spinning.
+    min_consecutive: usize,
+}
+
+impl SpinningDetector {
+    /// Create a new spinning detector.
+    ///
+    /// - `judge`: similarity judge to compare consecutive outputs.
+    /// - `threshold`: similarity score above which two outputs are "the same" (default 0.9).
+    /// - `min_consecutive`: how many consecutive similar pairs needed (default 2).
+    pub fn new(
+        judge: Box<dyn SimilarityJudge>,
+        threshold: SimilarityScore,
+        min_consecutive: usize,
+    ) -> Self {
+        Self {
+            judge,
+            threshold,
+            min_consecutive,
+        }
+    }
+}
+
+impl PatternDetector for SpinningDetector {
+    fn detect(&self, outputs: &[&str]) -> Option<StagnationDetection> {
+        if outputs.len() < 2 {
+            return None;
+        }
+
+        let mut consecutive = 0_usize;
+        let mut total_score = 0.0_f64;
+
+        for pair in outputs.windows(2) {
+            let score = self.judge.score(pair[0], pair[1]);
+            if score >= self.threshold {
+                consecutive += 1;
+                total_score += score;
+            } else {
+                consecutive = 0;
+                total_score = 0.0;
+            }
+
+            if consecutive >= self.min_consecutive {
+                let avg_score = total_score / consecutive as f64;
+                return Some(StagnationDetection {
+                    pattern: StagnationPattern::Spinning,
+                    confidence: avg_score,
+                    reason: format!(
+                        "{} consecutive pairs above threshold {:.2} (avg similarity {:.3})",
+                        consecutive, self.threshold, avg_score
+                    ),
+                });
+            }
+        }
+
+        None
+    }
+
+    fn target_pattern(&self) -> StagnationPattern {
+        StagnationPattern::Spinning
+    }
+}
+
+/// Detects [`StagnationPattern::Oscillation`] — alternating between a small set of outputs.
+///
+/// Checks if output[i] is similar to output[i-2] (A-B-A-B pattern).
+pub struct OscillationDetector {
+    judge: Box<dyn SimilarityJudge>,
+    /// Minimum similarity to consider two outputs as "the same".
+    threshold: SimilarityScore,
+    /// Number of oscillation cycles required.
+    min_cycles: usize,
+}
+
+impl OscillationDetector {
+    /// Create a new oscillation detector.
+    ///
+    /// - `judge`: similarity judge.
+    /// - `threshold`: similarity score above which two outputs are "the same" (default 0.9).
+    /// - `min_cycles`: how many A-B-A cycles needed (default 2).
+    pub fn new(
+        judge: Box<dyn SimilarityJudge>,
+        threshold: SimilarityScore,
+        min_cycles: usize,
+    ) -> Self {
+        Self {
+            judge,
+            threshold,
+            min_cycles,
+        }
+    }
+}
+
+impl PatternDetector for OscillationDetector {
+    fn detect(&self, outputs: &[&str]) -> Option<StagnationDetection> {
+        if outputs.len() < 4 {
+            return None;
+        }
+
+        let mut cycles = 0_usize;
+        let mut total_score = 0.0_f64;
+
+        // Check A-B-A pattern: output[i] ~ output[i-2]
+        for i in 2..outputs.len() {
+            let score = self.judge.score(outputs[i], outputs[i - 2]);
+            if score >= self.threshold {
+                cycles += 1;
+                total_score += score;
+            }
+        }
+
+        if cycles >= self.min_cycles {
+            let avg_score = total_score / cycles as f64;
+            return Some(StagnationDetection {
+                pattern: StagnationPattern::Oscillation,
+                confidence: avg_score,
+                reason: format!(
+                    "{} oscillation cycles detected (avg similarity {:.3})",
+                    cycles, avg_score
+                ),
+            });
+        }
+
+        None
+    }
+
+    fn target_pattern(&self) -> StagnationPattern {
+        StagnationPattern::Oscillation
+    }
+}
+
+/// Composite detector that runs multiple [`PatternDetector`]s and returns
+/// the highest-confidence detection.
+pub struct StagnationDetector {
+    detectors: Vec<Box<dyn PatternDetector>>,
+}
+
+impl StagnationDetector {
+    /// Create a composite from the given detectors.
+    pub fn new(detectors: Vec<Box<dyn PatternDetector>>) -> Self {
+        Self { detectors }
+    }
+
+    /// Run all detectors and return the detection with the highest confidence, if any.
+    pub fn detect(&self, outputs: &[&str]) -> Option<StagnationDetection> {
+        self.detectors
+            .iter()
+            .filter_map(|d| d.detect(outputs))
+            .max_by(|a, b| {
+                a.confidence
+                    .partial_cmp(&b.confidence)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stagnation::similarity::ExactHash;
+
+    #[test]
+    fn stagnation_pattern_display() {
+        assert_eq!(StagnationPattern::Spinning.to_string(), "spinning");
+        assert_eq!(StagnationPattern::Oscillation.to_string(), "oscillation");
+        assert_eq!(StagnationPattern::NoDrift.to_string(), "no_drift");
+        assert_eq!(
+            StagnationPattern::DiminishingReturns.to_string(),
+            "diminishing_returns"
+        );
+    }
+
+    #[test]
+    fn stagnation_pattern_serde_roundtrip() {
+        let pattern = StagnationPattern::Spinning;
+        let json = serde_json::to_string(&pattern).unwrap();
+        assert_eq!(json, "\"spinning\"");
+        let parsed: StagnationPattern = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, pattern);
+    }
+
+    #[test]
+    fn spinning_detector_not_enough_outputs() {
+        let detector = SpinningDetector::new(Box::new(ExactHash), 0.9, 2);
+        assert!(detector.detect(&["only one"]).is_none());
+    }
+
+    #[test]
+    fn spinning_detector_exact_repeats() {
+        let detector = SpinningDetector::new(Box::new(ExactHash), 0.9, 2);
+        let outputs = ["same", "same", "same"];
+        let result = detector.detect(&outputs.iter().map(|s| *s).collect::<Vec<_>>());
+        assert!(result.is_some());
+        let det = result.unwrap();
+        assert_eq!(det.pattern, StagnationPattern::Spinning);
+        assert!((det.confidence - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn spinning_detector_no_repeat() {
+        let detector = SpinningDetector::new(Box::new(ExactHash), 0.9, 2);
+        let outputs = ["a", "b", "c"];
+        assert!(detector.detect(&outputs).is_none());
+    }
+
+    #[test]
+    fn spinning_detector_interrupted_repeat() {
+        let detector = SpinningDetector::new(Box::new(ExactHash), 0.9, 2);
+        // "same", "same" is 1 consecutive pair, then "diff" breaks, "same", "same" is 1 pair
+        let outputs = ["same", "same", "diff", "same", "same"];
+        assert!(detector.detect(&outputs).is_none());
+    }
+
+    #[test]
+    fn oscillation_detector_not_enough_outputs() {
+        let detector = OscillationDetector::new(Box::new(ExactHash), 0.9, 2);
+        assert!(detector.detect(&["a", "b", "c"]).is_none());
+    }
+
+    #[test]
+    fn oscillation_detector_abab_pattern() {
+        let detector = OscillationDetector::new(Box::new(ExactHash), 0.9, 2);
+        // A, B, A, B — outputs[2]~outputs[0] and outputs[3]~outputs[1]
+        let outputs = ["fix A", "fix B", "fix A", "fix B"];
+        let result = detector.detect(&outputs);
+        assert!(result.is_some());
+        let det = result.unwrap();
+        assert_eq!(det.pattern, StagnationPattern::Oscillation);
+    }
+
+    #[test]
+    fn oscillation_detector_no_oscillation() {
+        let detector = OscillationDetector::new(Box::new(ExactHash), 0.9, 2);
+        let outputs = ["a", "b", "c", "d"];
+        assert!(detector.detect(&outputs).is_none());
+    }
+
+    #[test]
+    fn composite_stagnation_detector_picks_highest_confidence() {
+        let spinning = SpinningDetector::new(Box::new(ExactHash), 0.9, 2);
+        let oscillation = OscillationDetector::new(Box::new(ExactHash), 0.9, 2);
+        let detector = StagnationDetector::new(vec![Box::new(spinning), Box::new(oscillation)]);
+
+        // 3 identical outputs — spinning should fire
+        let outputs = ["same", "same", "same"];
+        let result = detector.detect(&outputs);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().pattern, StagnationPattern::Spinning);
+    }
+
+    #[test]
+    fn composite_stagnation_detector_empty() {
+        let detector = StagnationDetector::new(vec![]);
+        assert!(detector.detect(&["a", "b"]).is_none());
+    }
+
+    #[test]
+    fn stagnation_detection_serde_roundtrip() {
+        let det = StagnationDetection {
+            pattern: StagnationPattern::NoDrift,
+            confidence: 0.85,
+            reason: "no improvement".to_string(),
+        };
+        let json = serde_json::to_string(&det).unwrap();
+        let parsed: StagnationDetection = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.pattern, det.pattern);
+        assert!((parsed.confidence - det.confidence).abs() < f64::EPSILON);
+        assert_eq!(parsed.reason, det.reason);
+    }
+}

--- a/crates/belt-core/src/stagnation/pattern.rs
+++ b/crates/belt-core/src/stagnation/pattern.rs
@@ -249,7 +249,7 @@ mod tests {
     fn spinning_detector_exact_repeats() {
         let detector = SpinningDetector::new(Box::new(ExactHash), 0.9, 2);
         let outputs = ["same", "same", "same"];
-        let result = detector.detect(&outputs.to_vec());
+        let result = detector.detect(outputs.as_ref());
         assert!(result.is_some());
         let det = result.unwrap();
         assert_eq!(det.pattern, StagnationPattern::Spinning);

--- a/crates/belt-core/src/stagnation/pattern.rs
+++ b/crates/belt-core/src/stagnation/pattern.rs
@@ -249,7 +249,7 @@ mod tests {
     fn spinning_detector_exact_repeats() {
         let detector = SpinningDetector::new(Box::new(ExactHash), 0.9, 2);
         let outputs = ["same", "same", "same"];
-        let result = detector.detect(&outputs.iter().map(|s| *s).collect::<Vec<_>>());
+        let result = detector.detect(&outputs.iter().copied().collect::<Vec<_>>());
         assert!(result.is_some());
         let det = result.unwrap();
         assert_eq!(det.pattern, StagnationPattern::Spinning);

--- a/crates/belt-core/src/stagnation/pattern.rs
+++ b/crates/belt-core/src/stagnation/pattern.rs
@@ -249,7 +249,7 @@ mod tests {
     fn spinning_detector_exact_repeats() {
         let detector = SpinningDetector::new(Box::new(ExactHash), 0.9, 2);
         let outputs = ["same", "same", "same"];
-        let result = detector.detect(&outputs.iter().copied().collect::<Vec<_>>());
+        let result = detector.detect(&outputs.to_vec());
         assert!(result.is_some());
         let det = result.unwrap();
         assert_eq!(det.pattern, StagnationPattern::Spinning);

--- a/crates/belt-core/src/stagnation/similarity.rs
+++ b/crates/belt-core/src/stagnation/similarity.rs
@@ -1,0 +1,216 @@
+//! Similarity judgment for detecting repetitive agent outputs.
+//!
+//! Provides [`SimilarityJudge`] trait and two implementations:
+//! - [`ExactHash`]: byte-exact equality via hash comparison.
+//! - [`TokenFingerprint`]: normalized token-level similarity using Jaccard index.
+//! - [`CompositeSimilarity`]: combines multiple judges, returning the maximum score.
+
+use std::collections::HashSet;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+/// A similarity score in `[0.0, 1.0]` where 1.0 means identical.
+pub type SimilarityScore = f64;
+
+/// Judge how similar two text artifacts are.
+pub trait SimilarityJudge: Send + Sync {
+    /// Return a similarity score between `a` and `b`.
+    ///
+    /// The score MUST be in `[0.0, 1.0]`.
+    fn score(&self, a: &str, b: &str) -> SimilarityScore;
+
+    /// Human-readable name of this judge (for diagnostics).
+    fn name(&self) -> &str;
+}
+
+/// Exact byte-level equality via hashing.
+///
+/// Returns 1.0 if inputs hash identically, 0.0 otherwise.
+#[derive(Debug, Default)]
+pub struct ExactHash;
+
+impl ExactHash {
+    fn hash_str(s: &str) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        s.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+impl SimilarityJudge for ExactHash {
+    fn score(&self, a: &str, b: &str) -> SimilarityScore {
+        if Self::hash_str(a) == Self::hash_str(b) {
+            1.0
+        } else {
+            0.0
+        }
+    }
+
+    fn name(&self) -> &str {
+        "exact_hash"
+    }
+}
+
+/// Normalized token-level similarity using the Jaccard index.
+///
+/// Tokenizes by splitting on whitespace, lowercasing, and stripping
+/// non-alphanumeric characters. The score is `|intersection| / |union|`.
+#[derive(Debug, Default)]
+pub struct TokenFingerprint;
+
+impl TokenFingerprint {
+    fn tokenize(s: &str) -> HashSet<String> {
+        s.split_whitespace()
+            .map(|w| {
+                w.to_lowercase()
+                    .chars()
+                    .filter(|c| c.is_alphanumeric())
+                    .collect::<String>()
+            })
+            .filter(|t| !t.is_empty())
+            .collect()
+    }
+}
+
+impl SimilarityJudge for TokenFingerprint {
+    fn score(&self, a: &str, b: &str) -> SimilarityScore {
+        let set_a = Self::tokenize(a);
+        let set_b = Self::tokenize(b);
+
+        if set_a.is_empty() && set_b.is_empty() {
+            return 1.0;
+        }
+
+        let intersection = set_a.intersection(&set_b).count() as f64;
+        let union = set_a.union(&set_b).count() as f64;
+
+        if union == 0.0 {
+            return 1.0;
+        }
+
+        intersection / union
+    }
+
+    fn name(&self) -> &str {
+        "token_fingerprint"
+    }
+}
+
+/// Combines multiple [`SimilarityJudge`]s, returning the maximum score.
+pub struct CompositeSimilarity {
+    judges: Vec<Box<dyn SimilarityJudge>>,
+}
+
+impl CompositeSimilarity {
+    /// Create a new composite from the given judges.
+    pub fn new(judges: Vec<Box<dyn SimilarityJudge>>) -> Self {
+        Self { judges }
+    }
+}
+
+impl SimilarityJudge for CompositeSimilarity {
+    fn score(&self, a: &str, b: &str) -> SimilarityScore {
+        self.judges
+            .iter()
+            .map(|j| j.score(a, b))
+            .fold(0.0_f64, f64::max)
+    }
+
+    fn name(&self) -> &str {
+        "composite"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_hash_identical() {
+        let judge = ExactHash;
+        assert!((judge.score("hello world", "hello world") - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn exact_hash_different() {
+        let judge = ExactHash;
+        assert!((judge.score("hello", "world")).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn exact_hash_name() {
+        assert_eq!(ExactHash.name(), "exact_hash");
+    }
+
+    #[test]
+    fn token_fingerprint_identical() {
+        let judge = TokenFingerprint;
+        let score = judge.score("the quick brown fox", "the quick brown fox");
+        assert!((score - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn token_fingerprint_partial_overlap() {
+        let judge = TokenFingerprint;
+        // {"the", "quick", "brown", "fox"} vs {"the", "slow", "brown", "dog"}
+        // intersection = {"the", "brown"} = 2
+        // union = {"the", "quick", "brown", "fox", "slow", "dog"} = 6
+        let score = judge.score("the quick brown fox", "the slow brown dog");
+        assert!((score - 2.0 / 6.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn token_fingerprint_empty_both() {
+        let judge = TokenFingerprint;
+        assert!((judge.score("", "") - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn token_fingerprint_empty_one() {
+        let judge = TokenFingerprint;
+        assert!((judge.score("hello", "")).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn token_fingerprint_case_insensitive() {
+        let judge = TokenFingerprint;
+        let score = judge.score("Hello World", "hello world");
+        assert!((score - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn token_fingerprint_strips_punctuation() {
+        let judge = TokenFingerprint;
+        let score = judge.score("hello, world!", "hello world");
+        assert!((score - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn token_fingerprint_name() {
+        assert_eq!(TokenFingerprint.name(), "token_fingerprint");
+    }
+
+    #[test]
+    fn composite_returns_max() {
+        let composite =
+            CompositeSimilarity::new(vec![Box::new(ExactHash), Box::new(TokenFingerprint)]);
+        // Different strings but overlapping tokens — ExactHash=0.0, TokenFingerprint>0.0
+        let score = composite.score("hello world", "hello earth");
+        assert!(score > 0.0);
+        // Exact match — both return 1.0
+        let score = composite.score("hello", "hello");
+        assert!((score - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn composite_empty_judges() {
+        let composite = CompositeSimilarity::new(vec![]);
+        assert!((composite.score("a", "b")).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn composite_name() {
+        let composite = CompositeSimilarity::new(vec![]);
+        assert_eq!(composite.name(), "composite");
+    }
+}

--- a/crates/belt-daemon/src/evaluator.rs
+++ b/crates/belt-daemon/src/evaluator.rs
@@ -181,7 +181,6 @@ impl Evaluator {
         })
     }
 
-
     pub fn filter_completed(items: &[QueueItem]) -> Vec<&QueueItem> {
         items
             .iter()

--- a/crates/belt-infra/src/db.rs
+++ b/crates/belt-infra/src/db.rs
@@ -2157,6 +2157,7 @@ fn row_to_queue_item(row: &rusqlite::Row<'_>) -> Result<QueueItem, BeltError> {
             "spec_modification_proposed" => {
                 Ok(belt_core::queue::HitlReason::SpecModificationProposed)
             }
+            "stagnation_detected" => Ok(belt_core::queue::HitlReason::StagnationDetected),
             other => Err(BeltError::Database(format!("unknown hitl_reason: {other}"))),
         })
         .transpose()?;
@@ -2182,6 +2183,7 @@ fn row_to_queue_item(row: &rusqlite::Row<'_>) -> Result<QueueItem, BeltError> {
         replan_count: row.get::<_, u32>(14).unwrap_or(0),
         worktree_preserved: col(row, 15)?,
         previous_worktree_path: col(row, 16)?,
+        lateral_plan: col(row, 17).unwrap_or(None),
     })
 }
 
@@ -2212,6 +2214,7 @@ mod tests {
             worktree_preserved: false,
             previous_worktree_path: None,
             replan_count: 0,
+            lateral_plan: None,
         }
     }
 

--- a/crates/belt-infra/src/sources/github.rs
+++ b/crates/belt-infra/src/sources/github.rs
@@ -454,6 +454,7 @@ impl DataSource for GitHubDataSource {
                                 worktree_preserved: false,
                                 previous_worktree_path: None,
                                 replan_count: 0,
+                                lateral_plan: None,
                             });
                         }
                     }


### PR DESCRIPTION
## Summary

Autopilot 자동 구현

Closes #757

## Changes

- Add stagnation/ module with SimilarityJudge trait (ExactHash, TokenFingerprint, CompositeSimilarity)
- Add StagnationPattern enum (Spinning, Oscillation, NoDrift, DiminishingReturns)
- Add PatternDetector trait with SpinningDetector and OscillationDetector implementations
- Add StagnationDetector composite that selects highest-confidence detection
- Add LateralAnalyzer with Persona enum (Hacker, Architect, Researcher, Simplifier, Contrarian)
- Add lateral_plan field to QueueItem for storing serialized lateral plans
- Add HitlReason::StagnationDetected variant with exhaustive match coverage