### PR TITLE
docs: scaffold project values and layer rules

### DIFF
--- a/.claude/rules/commit-convention.md
+++ b/.claude/rules/commit-convention.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "CHANGELOG.md"
+  - ".github/**"
+---
+
 # Commit Convention (Release Please 연동)
 
 Conventional Commits 형식을 **반드시** 준수한다. Release Please가 커밋 메시지를 파싱하여 자동으로 버전을 결정한다.

--- a/.claude/rules/commit-convention.md
+++ b/.claude/rules/commit-convention.md
@@ -1,9 +1,3 @@
----
-paths:
-  - "CHANGELOG.md"
-  - ".github/**"
----
-
 # Commit Convention (Release Please 연동)
 
 Conventional Commits 형식을 **반드시** 준수한다. Release Please가 커밋 메시지를 파싱하여 자동으로 버전을 결정한다.

--- a/.claude/rules/rust-cli.md
+++ b/.claude/rules/rust-cli.md
@@ -1,6 +1,6 @@
 ---
 paths:
-  - "crates/belt-cli/**/*.rs"
+  - "**/belt-cli/**/*.rs"
 ---
 
 # CLI 레이어 컨벤션 (사용자 인터페이스)

--- a/.claude/rules/rust-core.md
+++ b/.claude/rules/rust-core.md
@@ -1,6 +1,6 @@
 ---
 paths:
-  - "crates/belt-core/**/*.rs"
+  - "**/belt-core/**/*.rs"
 ---
 
 # Core 레이어 컨벤션 (도메인 모델 / trait / enum)

--- a/.claude/rules/rust-daemon.md
+++ b/.claude/rules/rust-daemon.md
@@ -1,6 +1,6 @@
 ---
 paths:
-  - "crates/belt-daemon/**/*.rs"
+  - "**/belt-daemon/**/*.rs"
 ---
 
 # Daemon 레이어 컨벤션 (실행 루프 + Cron)

--- a/.claude/rules/rust-infra.md
+++ b/.claude/rules/rust-infra.md
@@ -1,6 +1,6 @@
 ---
 paths:
-  - "crates/belt-infra/**/*.rs"
+  - "**/belt-infra/**/*.rs"
 ---
 
 # Infrastructure 레이어 컨벤션 (외부 시스템 어댑터)

--- a/.claude/rules/rust-stagnation.md
+++ b/.claude/rules/rust-stagnation.md
@@ -1,0 +1,66 @@
+---
+paths:
+  - "**/stagnation/**/*.rs"
+---
+
+# Stagnation 모듈 컨벤션
+
+> 에이전트 루프 감지와 사고 전환 로직. 합성(Composite) 패턴으로 구성하고, Persona는 서브모듈에 격리한다.
+
+## 원칙
+
+1. **합성으로 조합하라**: SimilarityJudge와 PatternDetector는 항상 Composite를 통해 사용한다. 단일 구현을 직접 호출하면 확장 시 수정이 필요해진다.
+2. **빠른 실패 우선**: PatternDetector 체인 순서는 O(1) 검사 먼저. ExactHash → TokenFingerprint → NcdJudge 순서로 등록한다.
+3. **Persona 격리**: Persona 정의와 프롬프트 템플릿(`personas/*.md`)은 `lateral.rs` 내부에만 존재한다. core 외부에 노출하지 않는다.
+4. **결과는 LateralPlan으로 변환**: 분석 결과를 raw 문자열로 상위에 전달하지 않는다. `LateralPlan` 구조체로 변환 후 전달한다.
+
+## DO
+
+```rust
+// SimilarityJudge는 CompositeSimilarity로 조합한다
+let judge = CompositeSimilarity::new(vec![
+    Box::new(ExactHash),
+    Box::new(TokenFingerprint),
+    Box::new(NcdJudge::default()),
+]);
+
+// PatternDetector도 StagnationDetector로 합성한다 (빠른 실패 먼저)
+let detector = StagnationDetector::new(vec![
+    Box::new(SpinningDetector::new(Box::new(ExactHash), 0.9, 2)),  // O(1) — 먼저
+    Box::new(OscillationDetector::new(Box::new(TokenFingerprint), 0.9, 2)),
+]);
+
+// LateralPlan으로 변환하여 상위에 전달
+let plan: LateralPlan = analyzer.analyze(executor, &params).await?;
+```
+
+```rust
+// Persona는 lateral 모듈 내부에서만 구성한다
+// pub use lateral::{LateralAnalyzer, LateralPlan, Persona};  ← mod.rs re-export만 허용
+```
+
+## DON'T
+
+```rust
+// 단일 SimilarityJudge 구현을 직접 사용하지 않는다
+let judge = TokenFingerprint;  // 나쁨 — 나중에 NCD 추가 시 호출부 수정 필요
+let score = judge.score(a, b);
+
+// NcdJudge를 먼저 등록하지 않는다 — 압축 연산은 비싸다
+let detector = StagnationDetector::new(vec![
+    Box::new(NcdJudge::default()),   // 나쁨 — O(n log n) 연산이 먼저
+    Box::new(ExactHash),
+]);
+
+// Persona 구성 로직을 lateral 모듈 바깥에 두지 않는다
+let persona = Persona::Hacker;
+let prompt = persona.prompt_template();  // 나쁨 — 외부 코드가 prompt 조립을 담당
+```
+
+## 체크리스트
+
+- [ ] SimilarityJudge를 직접 사용하는 곳이 없고 CompositeSimilarity를 통하는가
+- [ ] PatternDetector 등록 순서가 O(1) 검사(ExactHash) 먼저인가
+- [ ] Persona 구성과 프롬프트 빌드가 `lateral.rs` 내부에만 있는가
+- [ ] 상위 레이어에 `StagnationDetection`이 아닌 `LateralPlan`을 전달하는가
+- [ ] `personas/` 서브모듈의 `.md` 파일이 `include_str!`로만 참조되는가

--- a/.claude/rules/spec-hierarchy.md
+++ b/.claude/rules/spec-hierarchy.md
@@ -1,6 +1,8 @@
 ---
 paths:
-  - "spec/**/*.md"
+  - "spec/DESIGN.md"
+  - "spec/concerns/*.md"
+  - "spec/flows/*.md"
 ---
 
 # Spec 문서 계층 구조

--- a/.claude/rules/workspace-schema.md
+++ b/.claude/rules/workspace-schema.md
@@ -1,0 +1,88 @@
+---
+paths:
+  - "**/*.yaml"
+  - "**/*.yml"
+---
+
+# workspace.yaml 스키마 컨벤션
+
+> workspace.yaml은 Belt의 단일 설정 파일(Single Source of Truth)이다. Daemon은 이 파일에 정의된 것만 실행한다.
+
+## 원칙
+
+1. **필수 필드**: `name`, `sources`, `concurrency`는 반드시 포함한다.
+2. **prompt/script 분리**: handler 하나는 `prompt` 또는 `script` 중 하나만 가진다. 혼용하지 않는다.
+3. **환경변수 주입은 2개만**: 핸들러 실행 시 주입되는 환경변수는 `WORK_ID`와 `WORKTREE`뿐이다. 추가 변수를 기대하는 스크립트를 작성하지 않는다.
+4. **on_done/on_fail은 side-effect 전용**: hook은 외부 시스템 반영(GitHub 댓글, 라벨 변경)을 담당한다. 도메인 로직을 넣지 않는다.
+
+## DO
+
+```yaml
+# 필수 필드를 모두 포함한 최소 구성
+name: my-project
+concurrency: 2
+
+sources:
+  github:
+    url: https://github.com/org/repo
+    states:
+      analyze:
+        trigger:
+          label: "belt:analyze"
+        handlers:
+          - prompt: "이슈를 분석하고 구현 계획을 작성해줘"
+        on_done:
+          - script: |
+              gh issue comment "$ISSUE" --body "분석 완료: $WORK_ID" -R org/repo
+        on_fail:
+          - script: |
+              gh issue comment "$ISSUE" --body "분석 실패: $WORK_ID" -R org/repo
+    escalation:
+      1: retry
+      2: hitl
+
+runtime:
+  default: claude
+  claude:
+    model: claude-sonnet-4-20250514
+```
+
+```yaml
+# prompt와 script를 별도 handler로 분리
+handlers:
+  - prompt: "구현 계획을 작성해줘"
+  - script: "cargo test"
+  - script: "cargo clippy -- -D warnings"
+```
+
+## DON'T
+
+```yaml
+# prompt와 script를 한 handler에 혼용하지 않는다
+handlers:
+  - prompt: "구현해줘"
+    script: "cargo test"   # 나쁨
+
+# WORK_ID, WORKTREE 외 환경변수를 기대하지 않는다
+handlers:
+  - script: "deploy.sh $DEPLOY_ENV"   # 나쁨 — DEPLOY_ENV는 주입되지 않음
+
+# on_done에 도메인 로직을 넣지 않는다
+on_done:
+  - script: |
+      if [ "$STATUS" = "success" ]; then   # 나쁨 — STATUS는 없음
+        gh pr merge ...
+      fi
+
+# escalation에 terminal 없이 hitl만 쓰면 무한 HITL 가능
+escalation:
+  1: hitl   # 나쁨 — terminal 정책 없음
+```
+
+## 체크리스트
+
+- [ ] `name`, `sources`, `concurrency` 필드가 있는가
+- [ ] 각 handler에 `prompt` 또는 `script` 중 하나만 있는가
+- [ ] 스크립트가 `WORK_ID`, `WORKTREE` 외 환경변수에 의존하지 않는가
+- [ ] `on_done`/`on_fail`이 외부 시스템 반영(GitHub 댓글 등)만 담당하는가
+- [ ] `escalation`에 최종 처리 정책(`hitl` 또는 `skip`)이 명시됐는가

--- a/.claude/rules/workspace-schema.md
+++ b/.claude/rules/workspace-schema.md
@@ -1,7 +1,8 @@
 ---
 paths:
-  - "**/*.yaml"
-  - "**/*.yml"
+  - "**/workspace*.yaml"
+  - "**/workspace*.yml"
+  - "tests/**/*.yaml"
 ---
 
 # workspace.yaml 스키마 컨벤션
@@ -10,7 +11,7 @@ paths:
 
 ## 원칙
 
-1. **필수 필드**: `name`, `sources`, `concurrency`는 반드시 포함한다.
+1. **필수 필드**: `name`은 반드시 포함한다. `sources`(기본 빈 맵)와 `concurrency`(기본 1)는 생략 가능하나 명시를 권장한다.
 2. **prompt/script 분리**: handler 하나는 `prompt` 또는 `script` 중 하나만 가진다. 혼용하지 않는다.
 3. **환경변수 주입은 2개만**: 핸들러 실행 시 주입되는 환경변수는 `WORK_ID`와 `WORKTREE`뿐이다. 추가 변수를 기대하는 스크립트를 작성하지 않는다.
 4. **on_done/on_fail은 side-effect 전용**: hook은 외부 시스템 반영(GitHub 댓글, 라벨 변경)을 담당한다. 도메인 로직을 넣지 않는다.
@@ -81,7 +82,7 @@ escalation:
 
 ## 체크리스트
 
-- [ ] `name`, `sources`, `concurrency` 필드가 있는가
+- [ ] `name` 필드가 있는가 (`sources`, `concurrency`는 명시 권장)
 - [ ] 각 handler에 `prompt` 또는 `script` 중 하나만 있는가
 - [ ] 스크립트가 `WORK_ID`, `WORKTREE` 외 환경변수에 의존하지 않는가
 - [ ] `on_done`/`on_fail`이 외부 시스템 반영(GitHub 댓글 등)만 담당하는가

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,3 +73,23 @@ gh workflow run release-please.yml   # Release PR 생성/업데이트 (수동)
 - Release PR 머지 시 자동으로 태그 생성 → release.yml 트리거 → 5개 플랫폼 바이너리 빌드 + GitHub Release
 
 PR 제목도 conventional commit 형식을 따른다 (squash merge 시 커밋 메시지로 사용됨).
+
+## 프로젝트 맥락
+
+- **종류**: 제품 (CLI 도구 + 데몬 서비스)
+- **팀**: 1인 개발
+- **주요 독자**: Rust 개발자
+
+## 엔지니어링 가치
+
+- 가독성 > 성능 (프로파일링으로 확인된 병목만 최적화)
+- 명시성 > 간결성 (trait 경계·에러 타입·match 브랜치 명시)
+- 안정성 > 속도 (의심스러우면 HITL)
+- 추상화는 Rule of 3 (3번 반복 전까지 명시적 중복 허용)
+
+## 문서화
+
+- **톤**: 기술적 한다체 (`~한다`, `~된다`)
+- **언어**: README=영어, spec/rules=한국어 기반, 기술용어=영어 원어 유지
+- **독자**: Rust 개발자 (코드 예시·trait 이름 자유롭게 사용)
+- **구조**: 비교/분류는 테이블 우선, 핵심 제약은 blockquote 강조


### PR DESCRIPTION
## Summary

- CLAUDE.md에 프로젝트 맥락·엔지니어링 가치·문서화 컨벤션 섹션 추가
- 기존 규칙 파일 6개의 paths를 범용화 (`crates/belt-*` → `**/belt-*`) — worktree 대응
- `spec-hierarchy.md`에서 `spec/archive/**` 제외
- `commit-convention.md`에 paths 추가하여 불필요한 항상 로드 방지
- `rust-stagnation.md` 신규 — stagnation 서브시스템 컨벤션
- `workspace-schema.md` 신규 — workspace.yaml 스키마 컨벤션

## Test plan

- [ ] `cargo build` 정상 빌드 확인 (코드 변경 없음)
- [ ] `.claude/rules/` 파일의 paths frontmatter가 올바르게 매칭되는지 확인
- [ ] CLAUDE.md 내용이 프로젝트 실제 가치관과 일치하는지 리뷰

🤖 Generated with [Claude Code](https://claude.com/claude-code)