### PR TITLE
fix(daemon): respect stagnation.enabled configuration flag

### DIFF
--- a/crates/belt-cli/src/agent.rs
+++ b/crates/belt-cli/src/agent.rs
@@ -370,6 +370,7 @@ fn default_agent_config() -> WorkspaceConfig {
         runtime: RuntimeConfig::default(),
         evaluate: None,
         claw_config: None,
+        stagnation: Default::default(),
     }
 }
 
@@ -643,6 +644,7 @@ mod tests {
             runtime: RuntimeConfig::default(),
             evaluate: None,
             claw_config: None,
+            stagnation: Default::default(),
         }
     }
 
@@ -702,6 +704,7 @@ mod tests {
             runtime: RuntimeConfig::default(),
             evaluate: None,
             claw_config: None,
+            stagnation: Default::default(),
         }
     }
 

--- a/crates/belt-core/src/stagnation/mod.rs
+++ b/crates/belt-core/src/stagnation/mod.rs
@@ -31,3 +31,26 @@ pub use pattern::{
 pub use similarity::{
     CompositeSimilarity, ExactHash, NcdJudge, SimilarityJudge, SimilarityScore, TokenFingerprint,
 };
+
+use serde::{Deserialize, Serialize};
+
+/// Stagnation detection configuration.
+///
+/// Controls whether stagnation analysis runs and its parameters.
+/// When `enabled` is `false`, the daemon skips stagnation detection entirely.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StagnationConfig {
+    /// Whether stagnation detection is enabled. Defaults to `true`.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+impl Default for StagnationConfig {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}

--- a/crates/belt-core/src/workspace.rs
+++ b/crates/belt-core/src/workspace.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::escalation::EscalationPolicy;
+use crate::stagnation::StagnationConfig;
 
 /// 워크스페이스 설정.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -20,6 +21,9 @@ pub struct WorkspaceConfig {
     /// Per-workspace Claw configuration overrides.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub claw_config: Option<ClawConfig>,
+    /// Stagnation detection configuration.
+    #[serde(default)]
+    pub stagnation: StagnationConfig,
 }
 
 /// Evaluation pipeline configuration.
@@ -449,5 +453,40 @@ evaluate: {}
         let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
         let eval = config.evaluate.unwrap();
         assert!(eval.mechanical.is_empty());
+    }
+
+    #[test]
+    fn stagnation_defaults_to_enabled() {
+        let yaml = "name: minimal\nsources:\n  github:\n    url: https://github.com/org/repo\n";
+        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.stagnation.enabled);
+    }
+
+    #[test]
+    fn stagnation_parses_disabled() {
+        let yaml = r#"
+name: stag-off
+sources:
+  github:
+    url: https://github.com/org/repo
+stagnation:
+  enabled: false
+"#;
+        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(!config.stagnation.enabled);
+    }
+
+    #[test]
+    fn stagnation_parses_enabled_explicitly() {
+        let yaml = r#"
+name: stag-on
+sources:
+  github:
+    url: https://github.com/org/repo
+stagnation:
+  enabled: true
+"#;
+        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.stagnation.enabled);
     }
 }

--- a/crates/belt-daemon/src/daemon.rs
+++ b/crates/belt-daemon/src/daemon.rs
@@ -2152,6 +2152,11 @@ impl Daemon {
         state: &str,
         current_error: &str,
     ) -> Option<String> {
+        // Respect stagnation.enabled configuration flag.
+        if !self.config.stagnation.enabled {
+            return None;
+        }
+
         // Collect recent failure error messages for this source_id + state.
         let errors: Vec<String> = self
             .history_events
@@ -5628,6 +5633,46 @@ sources:
         assert!(detail["confidence"].as_f64().unwrap() > 0.0);
         assert!(detail["recommended_persona"].as_str().is_some());
         assert!(detail["failure_count"].as_u64().unwrap() >= 1);
+    }
+
+    #[test]
+    fn detect_stagnation_disabled_skips_analysis() {
+        let tmp = TempDir::new().unwrap();
+        let source = MockDataSource::new("github");
+        let mut daemon = setup_daemon(&tmp, source, vec![0]);
+
+        // Disable stagnation detection via config.
+        daemon.config.stagnation.enabled = false;
+
+        // Record enough failures that would normally trigger stagnation.
+        let item = test_item("src:1", "implement");
+        for _ in 0..3 {
+            daemon.record_history_event(&item, "failed", Some("compile error X".to_string()));
+        }
+
+        let result = daemon.detect_stagnation_and_generate_plan(
+            "w:1",
+            "src:1",
+            "implement",
+            "compile error X",
+        );
+        assert!(
+            result.is_none(),
+            "stagnation detection should be skipped when disabled"
+        );
+    }
+
+    #[test]
+    fn detect_stagnation_enabled_by_default() {
+        let tmp = TempDir::new().unwrap();
+        let source = MockDataSource::new("github");
+        let daemon = setup_daemon(&tmp, source, vec![0]);
+
+        // Default config should have stagnation enabled.
+        assert!(
+            daemon.config.stagnation.enabled,
+            "stagnation should be enabled by default"
+        );
     }
 
     // --- handle_escalation with lateral_plan tests ---


### PR DESCRIPTION
## Summary

Respect the stagnation.enabled configuration flag in the daemon.

Closes #825

## Changes

Added StagnationConfig struct with enabled flag, integrated into WorkspaceConfig. Early-return guard implemented in detect_stagnation_and_generate_plan when disabled.