### PR TITLE
fix(daemon): respect lateral.enabled configuration flag

### DIFF
--- a/crates/belt-core/src/stagnation/mod.rs
+++ b/crates/belt-core/src/stagnation/mod.rs
@@ -34,6 +34,24 @@ pub use similarity::{
 
 use serde::{Deserialize, Serialize};
 
+/// Lateral thinking analysis configuration.
+///
+/// Controls whether lateral plan generation runs when stagnation is detected.
+/// When `enabled` is `false`, stagnation detection still runs but lateral plan
+/// generation is skipped.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LateralConfig {
+    /// Whether lateral thinking analysis is enabled. Defaults to `true`.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+}
+
+impl Default for LateralConfig {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
 /// Stagnation detection configuration.
 ///
 /// Controls whether stagnation analysis runs and its parameters.
@@ -43,6 +61,10 @@ pub struct StagnationConfig {
     /// Whether stagnation detection is enabled. Defaults to `true`.
     #[serde(default = "default_enabled")]
     pub enabled: bool,
+
+    /// Lateral thinking analysis sub-configuration.
+    #[serde(default)]
+    pub lateral: LateralConfig,
 }
 
 fn default_enabled() -> bool {
@@ -51,6 +73,9 @@ fn default_enabled() -> bool {
 
 impl Default for StagnationConfig {
     fn default() -> Self {
-        Self { enabled: true }
+        Self {
+            enabled: true,
+            lateral: LateralConfig::default(),
+        }
     }
 }

--- a/crates/belt-core/src/workspace.rs
+++ b/crates/belt-core/src/workspace.rs
@@ -489,4 +489,45 @@ stagnation:
         let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
         assert!(config.stagnation.enabled);
     }
+
+    #[test]
+    fn lateral_defaults_to_enabled() {
+        let yaml = "name: minimal\nsources:\n  github:\n    url: https://github.com/org/repo\n";
+        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.stagnation.lateral.enabled);
+    }
+
+    #[test]
+    fn lateral_parses_disabled() {
+        let yaml = r#"
+name: lat-off
+sources:
+  github:
+    url: https://github.com/org/repo
+stagnation:
+  lateral:
+    enabled: false
+"#;
+        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(
+            config.stagnation.enabled,
+            "stagnation should remain enabled"
+        );
+        assert!(!config.stagnation.lateral.enabled);
+    }
+
+    #[test]
+    fn lateral_parses_enabled_explicitly() {
+        let yaml = r#"
+name: lat-on
+sources:
+  github:
+    url: https://github.com/org/repo
+stagnation:
+  lateral:
+    enabled: true
+"#;
+        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.stagnation.lateral.enabled);
+    }
 }

--- a/crates/belt-daemon/src/daemon.rs
+++ b/crates/belt-daemon/src/daemon.rs
@@ -2157,6 +2157,11 @@ impl Daemon {
             return None;
         }
 
+        // Respect lateral.enabled configuration flag.
+        if !self.config.stagnation.lateral.enabled {
+            return None;
+        }
+
         // Collect recent failure error messages for this source_id + state.
         let errors: Vec<String> = self
             .history_events
@@ -5672,6 +5677,46 @@ sources:
         assert!(
             daemon.config.stagnation.enabled,
             "stagnation should be enabled by default"
+        );
+    }
+
+    #[test]
+    fn detect_stagnation_lateral_disabled_skips_plan_generation() {
+        let tmp = TempDir::new().unwrap();
+        let source = MockDataSource::new("github");
+        let mut daemon = setup_daemon(&tmp, source, vec![0]);
+
+        // Keep stagnation enabled but disable lateral analysis.
+        daemon.config.stagnation.lateral.enabled = false;
+
+        // Record enough failures that would normally trigger stagnation + lateral plan.
+        let item = test_item("src:1", "implement");
+        for _ in 0..3 {
+            daemon.record_history_event(&item, "failed", Some("compile error X".to_string()));
+        }
+
+        let result = daemon.detect_stagnation_and_generate_plan(
+            "w:1",
+            "src:1",
+            "implement",
+            "compile error X",
+        );
+        assert!(
+            result.is_none(),
+            "lateral plan generation should be skipped when lateral.enabled is false"
+        );
+    }
+
+    #[test]
+    fn detect_stagnation_lateral_enabled_by_default() {
+        let tmp = TempDir::new().unwrap();
+        let source = MockDataSource::new("github");
+        let daemon = setup_daemon(&tmp, source, vec![0]);
+
+        // Default config should have lateral enabled.
+        assert!(
+            daemon.config.stagnation.lateral.enabled,
+            "lateral should be enabled by default"
         );
     }
 


### PR DESCRIPTION
## Summary

Added LateralConfig with enabled flag to StagnationConfig, early-return guard in daemon.rs when lateral disabled.

Closes #828