### PR TITLE
ci: refine release workflow and enforce clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --all-targets --all-features
+      - run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
     name: Test (${{ matrix.os }})

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,28 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+  # Safety net: fail the workflow if the HEAD commit is a merged Release PR
+  # but release-please did not create a tag. This turns silent release-skip
+  # (e.g. the 2026-03 skip-labeling regression that produced v0.1.7-v0.1.10
+  # commits without matching tags) into a loud CI failure.
+  verify-release:
+    needs: release-please
+    if: always() && needs.release-please.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect silently-skipped release
+        env:
+          RELEASE_CREATED: ${{ needs.release-please.outputs.release_created }}
+        run: |
+          msg=$(git log -1 --pretty=%s)
+          if [[ "$msg" =~ ^chore\(main\):\ release ]] && [[ "$RELEASE_CREATED" != "true" ]]; then
+            echo "::error::HEAD commit is a Release PR merge ('$msg') but release-please did not create a tag (release_created=$RELEASE_CREATED)."
+            echo "::error::Recovery: add the 'release-please:force-run' label to the merged PR, then re-run this workflow."
+            exit 1
+          fi
+          echo "Release guard OK (HEAD: $msg, release_created=$RELEASE_CREATED)"
+
   build-and-upload:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,14 +1,13 @@
 name: Release Please
 
 on:
-  # Manual: creates/updates Release PR
+  # Manual: creates/updates Release PR on demand
   workflow_dispatch:
-  # Auto: detects merged Release PR and creates tag + release
+  # Auto: every main push (both feature commits and Release PR merges).
+  # Feature commits refresh the open Release PR; Release PR merges produce the tag + GitHub Release.
   push:
     branches:
       - main
-    paths:
-      - '.release-please-manifest.json'
 
 permissions:
   contents: write
@@ -26,7 +25,6 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          skip-labeling: true
 
   build-and-upload:
     needs: release-please


### PR DESCRIPTION
## Summary
This PR updates the CI/CD configuration to improve the release automation process and strengthen code quality checks.

## Key Changes
- **Release workflow refinement**: Removed the `paths` filter from the `push` trigger in `release-please.yml` so that every push to main triggers the release workflow. This allows feature commits to refresh the open Release PR, while Release PR merges produce the tag and GitHub Release.
- **Improved workflow documentation**: Updated comments in `release-please.yml` to clarify the dual behavior of the workflow (manual dispatch and automatic on every main push).
- **Removed skip-labeling option**: Deleted the `skip-labeling: true` configuration from the release-please action to enable automatic labeling of release PRs.
- **Enforce clippy warnings**: Added `-D warnings` flag to the clippy command in `ci.yml` to treat all warnings as errors, ensuring stricter code quality standards.

## Notable Details
The release workflow now operates on every push to main rather than only when the manifest file changes, enabling more responsive Release PR management while maintaining the same end result for actual releases.

https://claude.ai/code/session_01Fv3UBPT1CtrqTRgC9rRxif