### PR TITLE
ci(release): add tag push trigger as binary build safety net

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,29 @@
 name: Release
 
 on:
+  # Called by release-please.yml after it creates a tag + GitHub Release.
   workflow_call:
     inputs:
       tag_name:
         required: true
         type: string
+  # Manual recovery: build + upload assets for an existing tag.
   workflow_dispatch:
     inputs:
       tag_name:
         description: 'Tag name (e.g. v0.1.5)'
         required: true
         type: string
+  # Safety net: any `v*` tag push triggers a build, so tags created outside
+  # release-please (manual backfill, recovery) still produce binaries.
+  push:
+    tags:
+      - 'v*'
+
+# Prevent two builds racing for the same tag (e.g. workflow_call + push.tags).
+concurrency:
+  group: release-${{ inputs.tag_name || github.ref_name }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -44,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag_name }}
+          ref: ${{ inputs.tag_name || github.ref_name }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -104,5 +116,5 @@ jobs:
       - name: Upload assets to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ inputs.tag_name }}
+          tag_name: ${{ inputs.tag_name || github.ref_name }}
           files: artifacts/*


### PR DESCRIPTION
## Summary
- Add `on.push.tags: ['v*']` trigger to `release.yml` so any v*-prefixed tag produces binaries, regardless of how the tag was created
- Add `concurrency` group keyed by tag name to prevent two runs racing for the same tag (e.g. `workflow_call` from release-please + `push.tags` from the same tag)
- Resolve `tag_name` from either `inputs.tag_name` (workflow_call/dispatch) or `github.ref_name` (tag push) in `checkout.ref` and `action-gh-release.tag_name`

## Why
Builds previously only ran when release-please invoked `release.yml` via `workflow_call`. The recent skip-labeling regression produced `v0.1.7`–`v0.1.10` release commits on main without any matching tags, and there was no way to recover the binaries short of editing the workflow. This PR closes that hole: manual backfill tags (or any recovery path that pushes a `v*` tag) now triggers the full build + asset upload.

Paired with the `verify-release` guard added in #865, the release pipeline now fails loudly on silent skips and has a recovery path that doesn't require code changes.

## Test plan
- [ ] Merge and observe the `Release` workflow triggering on the next release-please tag (workflow_call path, unchanged behavior)
- [ ] Push a `v0.1.7` recovery tag manually and confirm the `Release` workflow runs and uploads artifacts to the corresponding GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)