### PR TITLE
ci(release): smoke-test binaries against tag version before upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,30 @@ jobs:
           fi
         shell: bash
 
+      # Runs on natively-executable targets only: cross builds (aarch64 Linux on x64
+      # Linux runner) and x86_64-apple-darwin (macos-latest is arm64; Rosetta presence
+      # is not contractual) are skipped. Verifies both that the binary runs and that
+      # it reports the same version as the tag being released.
+      - name: Smoke test binary
+        if: matrix.cross != true && matrix.target != 'x86_64-apple-darwin'
+        shell: bash
+        run: |
+          expected="${{ inputs.tag_name || github.ref_name }}"
+          expected="${expected#v}"
+          if [ "${{ matrix.archive }}" = "zip" ]; then
+            bin="./target/${{ matrix.target }}/release/belt.exe"
+          else
+            bin="./target/${{ matrix.target }}/release/belt"
+          fi
+          out=$("$bin" --version 2>&1)
+          echo "Binary reports: $out"
+          actual=$(printf '%s' "$out" | awk '{print $NF}')
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Binary version '$actual' does not match tag '$expected'"
+            exit 1
+          fi
+          echo "Smoke test OK: binary version matches tag ($expected)"
+
       - name: Package (tar.gz)
         if: matrix.archive == 'tar.gz'
         run: |


### PR DESCRIPTION
## Summary
Added a smoke test step to the release workflow that verifies the compiled binary runs correctly and reports the expected version matching the release tag.

## Key Changes
- New "Smoke test binary" step in the release workflow that:
  - Runs only on natively-executable targets (skips cross-compiled builds and x86_64-apple-darwin on arm64 runners)
  - Extracts the expected version from the release tag
  - Executes the compiled binary with `--version` flag
  - Compares the reported version against the expected tag version
  - Fails the workflow if versions don't match, preventing invalid releases

## Implementation Details
- Handles both Windows (`.exe`) and Unix binary paths based on the archive format
- Strips the leading 'v' from the tag name to match the binary's version output format
- Uses `awk` to extract the version number from the binary's output (assumes it's the last field)
- Provides clear error messages and logging for debugging version mismatches

https://claude.ai/code/session_011gh13DXdwEkbrC55EvmPVt